### PR TITLE
Make colors customizable

### DIFF
--- a/library/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/library/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -43,15 +43,12 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
     private static final int NORMAL_INTERVAL = 50;
 
-    @ColorInt
-    private final int themeAccentColor;
-    @ColorInt
-    private final int themeIconColor;
+    @ColorInt private final int themeAccentColor;
+    @ColorInt private final int themeIconColor;
 
     private final ImageView[] emojiTabs;
 
-    @Nullable
-    OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+    @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
 
     private int emojiTabLastSelectedIndex = -1;
     private RecentEmojiGridView recentGridView;

--- a/library/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/library/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 
 @SuppressLint("ViewConstructor")
 final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
-
     private static final int RECENT_INDEX = 0;
     private static final int PEOPLE_INDEX = 1;
     private static final int NATURE_INDEX = 2;
@@ -48,9 +47,12 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     private final int themeAccentColor;
     @ColorInt
     private final int themeIconColor;
+
     private final ImageView[] emojiTabs;
+
     @Nullable
     OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+
     private int emojiTabLastSelectedIndex = -1;
     private RecentEmojiGridView recentGridView;
 
@@ -110,7 +112,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     }
 
     private void tintIcons() {
-        for (ImageView emojiTab : emojiTabs) {
+        for (final ImageView emojiTab : emojiTabs) {
             emojiTab.setColorFilter(themeIconColor, PorterDuff.Mode.SRC_IN);
         }
 

--- a/library/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/library/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -6,11 +6,13 @@ import android.graphics.PorterDuff;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+
 import com.vanniktech.emoji.emoji.Cars;
 import com.vanniktech.emoji.emoji.Electronics;
 import com.vanniktech.emoji.emoji.Emoji;
@@ -22,13 +24,13 @@ import com.vanniktech.emoji.emoji.Symbols;
 import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiClickedListener;
 import com.vanniktech.emoji.listeners.RepeatListener;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @SuppressLint("ViewConstructor")
 final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
-    private static final int BACKGROUND_COLOR = 0xffeceff1;
 
     private static final int RECENT_INDEX = 0;
     private static final int PEOPLE_INDEX = 1;
@@ -42,13 +44,14 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
     private static final int NORMAL_INTERVAL = 50;
 
-    @ColorInt private final int themeAccentColor;
-    @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
-
-    private int emojiTabLastSelectedIndex = -1;
-
+    @ColorInt
+    private final int themeAccentColor;
+    @ColorInt
+    private final int themeIconColor;
     private final ImageView[] emojiTabs;
-
+    @Nullable
+    OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+    private int emojiTabLastSelectedIndex = -1;
     private RecentEmojiGridView recentGridView;
 
     EmojiView(final Context context, final OnEmojiClickedListener onEmojiClickedListener, @NonNull final RecentEmoji recentEmoji) {
@@ -57,7 +60,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
         View.inflate(context, R.layout.emoji_view, this);
 
         setOrientation(VERTICAL);
-        setBackgroundColor(BACKGROUND_COLOR);
+        setBackgroundColor(ContextCompat.getColor(context, R.color.emoji_background));
 
         final ViewPager emojisPager = (ViewPager) findViewById(R.id.emojis_pager);
         emojisPager.addOnPageChangeListener(this);
@@ -87,9 +90,13 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
             }
         }));
 
+        themeIconColor = ContextCompat.getColor(context, R.color.emoji_icons);
+
         final TypedValue value = new TypedValue();
         context.getTheme().resolveAttribute(R.attr.colorAccent, value, true);
         themeAccentColor = value.data;
+
+        tintIcons();
 
         final int startIndex = recentGridView.numberOfRecentEmojis() > 0 ? RECENT_INDEX : PEOPLE_INDEX;
         emojisPager.setCurrentItem(startIndex);
@@ -100,6 +107,14 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
         for (int i = 0; i < emojiTabs.length; i++) {
             emojiTabs[i].setOnClickListener(new EmojiTabsClickListener(emojisPager, i));
         }
+    }
+
+    private void tintIcons() {
+        for (ImageView emojiTab : emojiTabs) {
+            emojiTab.setColorFilter(themeIconColor, PorterDuff.Mode.SRC_IN);
+        }
+
+        ((ImageView) findViewById(R.id.emojis_backspace)).setColorFilter(themeIconColor, PorterDuff.Mode.SRC_IN);
     }
 
     public void setOnEmojiBackspaceClickListener(@Nullable final OnEmojiBackspaceClickListener onEmojiBackspaceClickListener) {
@@ -145,7 +160,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
                 case SYMBOLS_INDEX:
                     if (emojiTabLastSelectedIndex >= 0 && emojiTabLastSelectedIndex < emojiTabs.length) {
                         emojiTabs[emojiTabLastSelectedIndex].setSelected(false);
-                        emojiTabs[emojiTabLastSelectedIndex].clearColorFilter();
+                        emojiTabs[emojiTabLastSelectedIndex].setColorFilter(themeIconColor, PorterDuff.Mode.SRC_IN);
                     }
 
                     emojiTabs[i].setSelected(true);

--- a/library/src/main/res/layout/emoji_view.xml
+++ b/library/src/main/res/layout/emoji_view.xml
@@ -14,7 +14,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_recent"
-            android:src="@drawable/emoji_recent"/>
+            android:src="@drawable/emoji_recent" />
 
         <ImageButton
             android:id="@+id/emojis_tab_1_people"
@@ -23,7 +23,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_people"
-            android:src="@drawable/emoji_people"/>
+            android:src="@drawable/emoji_people" />
 
         <ImageButton
             android:id="@+id/emojis_tab_2_nature"
@@ -32,7 +32,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_nature"
-            android:src="@drawable/emoji_nature"/>
+            android:src="@drawable/emoji_nature" />
 
         <ImageButton
             android:id="@+id/emojis_tab_3_food"
@@ -41,7 +41,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_food"
-            android:src="@drawable/emoji_food"/>
+            android:src="@drawable/emoji_food" />
 
         <ImageButton
             android:id="@+id/emojis_tab_4_sport"
@@ -50,7 +50,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_sport"
-            android:src="@drawable/emoji_sport"/>
+            android:src="@drawable/emoji_sport" />
 
         <ImageButton
             android:id="@+id/emojis_tab_5_cars"
@@ -59,7 +59,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_cars"
-            android:src="@drawable/emoji_cars"/>
+            android:src="@drawable/emoji_cars" />
 
         <ImageButton
             android:id="@+id/emojis_tab_6_electronics"
@@ -68,7 +68,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_electronics"
-            android:src="@drawable/emoji_electronics"/>
+            android:src="@drawable/emoji_electronics" />
 
         <ImageButton
             android:id="@+id/emojis_tab_7_symbols"
@@ -77,7 +77,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_symbols"
-            android:src="@drawable/emoji_symbols"/>
+            android:src="@drawable/emoji_symbols" />
 
         <ImageButton
             android:id="@+id/emojis_backspace"
@@ -86,16 +86,16 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_backspace"
-            android:src="@drawable/emoji_backspace_back_normal"/>
+            android:src="@drawable/emoji_backspace_back_normal" />
     </LinearLayout>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="#626e76"/>
+        android:background="@color/emoji_divider" />
 
     <android.support.v4.view.ViewPager
         android:id="@+id/emojis_pager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 </merge>

--- a/library/src/main/res/layout/emoji_view.xml
+++ b/library/src/main/res/layout/emoji_view.xml
@@ -14,7 +14,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_recent"
-            android:src="@drawable/emoji_recent" />
+            android:src="@drawable/emoji_recent"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_1_people"
@@ -23,7 +23,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_people"
-            android:src="@drawable/emoji_people" />
+            android:src="@drawable/emoji_people"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_2_nature"
@@ -32,7 +32,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_nature"
-            android:src="@drawable/emoji_nature" />
+            android:src="@drawable/emoji_nature"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_3_food"
@@ -41,7 +41,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_food"
-            android:src="@drawable/emoji_food" />
+            android:src="@drawable/emoji_food"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_4_sport"
@@ -50,7 +50,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_sport"
-            android:src="@drawable/emoji_sport" />
+            android:src="@drawable/emoji_sport"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_5_cars"
@@ -59,7 +59,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_cars"
-            android:src="@drawable/emoji_cars" />
+            android:src="@drawable/emoji_cars"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_6_electronics"
@@ -68,7 +68,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_electronics"
-            android:src="@drawable/emoji_electronics" />
+            android:src="@drawable/emoji_electronics"/>
 
         <ImageButton
             android:id="@+id/emojis_tab_7_symbols"
@@ -77,7 +77,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_symbols"
-            android:src="@drawable/emoji_symbols" />
+            android:src="@drawable/emoji_symbols"/>
 
         <ImageButton
             android:id="@+id/emojis_backspace"
@@ -86,16 +86,16 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/emoji_backspace"
-            android:src="@drawable/emoji_backspace_back_normal" />
+            android:src="@drawable/emoji_backspace_back_normal"/>
     </LinearLayout>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="@color/emoji_divider" />
+        android:background="@color/emoji_divider"/>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/emojis_pager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"/>
 </merge>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="emoji_background">#ECEFF1</color>
     <color name="emoji_icons">#61000000</color>
-    <color name="emoji_divider">#1B000000</color>
+    <color name="emoji_divider">#1F000000</color>
 </resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="emoji_background">#ECEFF1</color>
     <color name="emoji_icons">#61000000</color>
-    <color name="emoji_divider">#15000000</color>
+    <color name="emoji_divider">#1B000000</color>
 </resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="emoji_background">#ECEFF1</color>
+    <color name="emoji_icons">#61000000</color>
+    <color name="emoji_divider">#15000000</color>
+</resources>


### PR DESCRIPTION
This would make the used colors customizable by introducing the following color resources:

```xml
<color name="emoji_background">#ECEFF1</color>
<color name="emoji_icons">#61000000</color>
<color name="emoji_divider">#15000000</color>
```

This is especially useful when implementing a [DayNight Theme](https://medium.com/@chrisbanes/appcompat-v23-2-daynight-d10f90c83e94#.m7enybk9k), but also has more use cases. 

Moreover the default colors were updated to the recommended ones, found at the [official doc](https://material.io/guidelines/style/color.html).

The `EmojiView` now looks like this:

![New look](https://cloud.githubusercontent.com/assets/8021265/21535523/70e2d3e8-cd76-11e6-87e2-3f3d8d3b9e13.png)

If you are interested, I can also update the sample to have an option for a dark theme.