### PR TITLE
Make the EmojiEditText more performant

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
@@ -3,9 +3,7 @@ package com.vanniktech.emoji;
 import android.content.Context;
 import android.support.v4.util.Pair;
 import android.text.Spannable;
-
 import com.vanniktech.emoji.emoji.Emoji;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
@@ -80,13 +80,5 @@ final class EmojiHandler {
       this.start = start;
       this.end = end;
     }
-
-    int getStart() {
-      return start;
-    }
-
-    int getEnd() {
-      return end;
-    }
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
@@ -1,7 +1,6 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
-import android.support.v4.util.Pair;
 import android.text.Spannable;
 import com.vanniktech.emoji.emoji.Emoji;
 import java.util.ArrayList;
@@ -10,10 +9,6 @@ import java.util.List;
 import static com.vanniktech.emoji.EmojiHandler.SpanRangeList.SPAN_NOT_FOUND;
 
 final class EmojiHandler {
-  private EmojiHandler() {
-    throw new AssertionError("No instances.");
-  }
-
   static void addEmojis(final Context context, final Spannable text, final int emojiSize) {
     final SpanRangeList existingSpanRanges = new SpanRangeList(text);
     final EmojiManager emojiManager = EmojiManager.getInstance();
@@ -41,21 +36,25 @@ final class EmojiHandler {
     }
   }
 
+  private EmojiHandler() {
+    throw new AssertionError("No instances.");
+  }
+
   static final class SpanRangeList {
     static final int SPAN_NOT_FOUND = -1;
 
-    private final List<Pair<Integer, Integer>> spanRanges = new ArrayList<>();
+    private final List<Range> spanRanges = new ArrayList<>();
 
     SpanRangeList(final Spannable text) {
       for (final EmojiSpan span : text.getSpans(0, text.length(), EmojiSpan.class)) {
-        spanRanges.add(new Pair<>(text.getSpanStart(span), text.getSpanEnd(span)));
+        spanRanges.add(new Range(text.getSpanStart(span), text.getSpanEnd(span)));
       }
     }
 
     int spanEnd(final int index) {
-      for (final Pair<Integer, Integer> spanRange : spanRanges) {
-        if (spanRange.first == index) {
-          return spanRange.second;
+      for (final Range spanRange : spanRanges) {
+        if (spanRange.start == index) {
+          return spanRange.end;
         }
       }
 
@@ -63,13 +62,31 @@ final class EmojiHandler {
     }
 
     int nextSpanStart(final int index) {
-      for (final Pair<Integer, Integer> spanRange : spanRanges) {
-        if (spanRange.first > index) {
-          return spanRange.first;
+      for (final Range spanRange : spanRanges) {
+        if (spanRange.start > index) {
+          return spanRange.start;
         }
       }
 
       return SPAN_NOT_FOUND;
+    }
+  }
+
+  static final class Range {
+    final int start;
+    final int end;
+
+    Range(final int start, final int end) {
+      this.start = start;
+      this.end = end;
+    }
+
+    int getStart() {
+      return start;
+    }
+
+    int getEnd() {
+      return end;
     }
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
@@ -2,33 +2,46 @@ package com.vanniktech.emoji;
 
 import android.content.Context;
 import android.text.Spannable;
+import android.util.SparseIntArray;
+
 import com.vanniktech.emoji.emoji.Emoji;
 
 final class EmojiHandler {
-  static void addEmojis(final Context context, final Spannable text, final int emojiSize) {
-    final EmojiSpan[] spans = text.getSpans(0, text.length(), EmojiSpan.class);
+  private EmojiHandler() {
+    throw new AssertionError("No instances.");
+  }
 
-    for (final EmojiSpan oldSpan : spans) {
-      text.removeSpan(oldSpan);
+  static void addEmojis(final Context context, final Spannable text, final int emojiSize) {
+    final EmojiSpan[] existingSpans = text.getSpans(0, text.length(), EmojiSpan.class);
+    final SparseIntArray existingSpanRanges = new SparseIntArray();
+
+    for (final EmojiSpan span : existingSpans) {
+      final int spanStart = text.getSpanStart(span);
+      final int spanEnd = text.getSpanEnd(span);
+
+      existingSpanRanges.append(spanStart, spanEnd);
     }
 
     int i = 0;
-
-    final EmojiManager instance = EmojiManager.getInstance();
+    final EmojiManager emojiManager = EmojiManager.getInstance();
 
     while (i < text.length()) {
-      final Emoji found = instance.findEmoji(text.subSequence(i, text.length()));
+      final int existingSpanEnd = existingSpanRanges.get(i, -1);
 
-      if (found != null) {
-        text.setSpan(new EmojiSpan(context, found.getResource(), emojiSize), i, i + found.getLength(), Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
-        i += found.getLength();
+      if (existingSpanEnd == -1) {
+        final Emoji found = emojiManager.findEmoji(text.subSequence(i, text.length()));
+
+        if (found != null) {
+          text.setSpan(new EmojiSpan(context, found.getResource(), emojiSize), i, i + found.getLength(),
+                  Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+          i += found.getLength();
+        } else {
+          i++;
+        }
       } else {
-        i++;
+        i += existingSpanEnd - i;
       }
     }
-  }
-
-  private EmojiHandler() {
-    throw new AssertionError("No instances.");
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiHandler.java
@@ -43,7 +43,7 @@ final class EmojiHandler {
     }
   }
 
-  static class SpanRangeList {
+  static final class SpanRangeList {
     static final int SPAN_NOT_FOUND = -1;
 
     private final List<Pair<Integer, Integer>> spanRanges = new ArrayList<>();
@@ -61,7 +61,7 @@ final class EmojiHandler {
         }
       }
 
-      return -1;
+      return SPAN_NOT_FOUND;
     }
 
     int nextSpanStart(final int index) {
@@ -71,7 +71,7 @@ final class EmojiHandler {
         }
       }
 
-      return -1;
+      return SPAN_NOT_FOUND;
     }
   }
 }


### PR DESCRIPTION
The problem was the recalculation of all spans when changing the text.
With this change, the existing spans are reused and only new text is taken into account.
Furthermore the flag `SPAN_EXCLUSIVE_EXCLUSIVE` is now in use, which causes spans with the length 0 (When an emoji has been deleted) to be automatically removed by the platform.
This also reduces the calls to `findEmoji`, which can add up to bad performance.

The problem still persists when text is inserted at the start of the `Spannable` though, as the spans get recalculated by the platform then, but there is sadly nothing we can do about that.