### PR TITLE
Improve Popup logic

### DIFF
--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
@@ -147,7 +147,7 @@ public class MainActivity extends AppCompatActivity {
         })
         .setOnSoftKeyboardCloseListener(new OnSoftKeyboardCloseListener() {
           @Override public void onKeyboardClose() {
-            emojiPopup.dismiss();
+            Log.d(TAG, "Closed soft keyboard");
           }
         })
         .build(editText);

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
@@ -82,6 +82,9 @@ public class MainActivity extends AppCompatActivity {
 
   @Override public boolean onOptionsItemSelected(final MenuItem item) {
     switch (item.getItemId()) {
+      case R.id.show_dialog:
+        MainDialog.show(this);
+        return true;
       case R.id.variantIos:
         EmojiManager.install(new IosEmojiProvider());
         recreate();

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
@@ -46,6 +46,14 @@ public class MainDialog extends DialogFragment {
     chatAdapter = new ChatAdapter();
   }
 
+  @Override public void onStop() {
+    if (emojiPopup != null) {
+      emojiPopup.dismiss();
+    }
+
+    super.onStop();
+  }
+
   @NonNull @Override
   public Dialog onCreateDialog(final Bundle savedInstanceState) {
     return new AlertDialog.Builder(getContext())

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
@@ -1,0 +1,128 @@
+package com.vanniktech.emoji.sample;
+
+import android.app.Dialog;
+import android.graphics.PorterDuff;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import com.vanniktech.emoji.EmojiEditText;
+import com.vanniktech.emoji.EmojiPopup;
+import com.vanniktech.emoji.emoji.Emoji;
+import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
+import com.vanniktech.emoji.listeners.OnEmojiClickedListener;
+import com.vanniktech.emoji.listeners.OnEmojiPopupDismissListener;
+import com.vanniktech.emoji.listeners.OnEmojiPopupShownListener;
+import com.vanniktech.emoji.listeners.OnSoftKeyboardCloseListener;
+import com.vanniktech.emoji.listeners.OnSoftKeyboardOpenListener;
+
+public class MainDialog extends DialogFragment {
+  private static final String FRAGMENT_MANAGER_TAG = "dialog_main";
+  private static final String TAG = "MainDialog";
+
+  private ChatAdapter chatAdapter;
+  private EmojiPopup emojiPopup;
+
+  private EmojiEditText editText;
+  private ViewGroup rootView;
+  private ImageView emojiButton;
+
+  public static void show(@NonNull final AppCompatActivity activity) {
+    new MainDialog().show(activity.getSupportFragmentManager(), FRAGMENT_MANAGER_TAG);
+  }
+
+  @Override public void onCreate(@Nullable final Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    chatAdapter = new ChatAdapter();
+  }
+
+  @NonNull @Override
+  public Dialog onCreateDialog(final Bundle savedInstanceState) {
+    return new AlertDialog.Builder(getContext())
+            .setView(buildView())
+            .create();
+  }
+
+  private View buildView() {
+    final View result = View.inflate(getContext(), R.layout.dialog_main, null);
+
+    editText = (EmojiEditText) result.findViewById(R.id.main_dialog_chat_bottom_message_edittext);
+    rootView = (ViewGroup) result.findViewById(R.id.main_dialog_root_view);
+    emojiButton = (ImageView) result.findViewById(R.id.main_dialog_emoji);
+    final ImageView sendButton = (ImageView) result.findViewById(R.id.main_dialog_send);
+
+    emojiButton.setColorFilter(ContextCompat.getColor(getContext(), R.color.emoji_icons), PorterDuff.Mode.SRC_IN);
+    sendButton.setColorFilter(ContextCompat.getColor(getContext(), R.color.emoji_icons), PorterDuff.Mode.SRC_IN);
+
+    emojiButton.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(final View v) {
+        emojiPopup.toggle();
+      }
+    });
+    sendButton.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(final View v) {
+        final String text = editText.getText().toString().trim();
+
+        if (text.length() > 0) {
+          chatAdapter.add(text);
+
+          editText.setText("");
+        }
+      }
+    });
+
+    final RecyclerView recyclerView = (RecyclerView) result.findViewById(R.id.main_dialog_recycler_view);
+    recyclerView.setAdapter(chatAdapter);
+    recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false));
+
+    setUpEmojiPopup();
+
+    return rootView;
+  }
+
+  private void setUpEmojiPopup() {
+    emojiPopup = EmojiPopup.Builder.fromRootView(rootView)
+            .setOnEmojiBackspaceClickListener(new OnEmojiBackspaceClickListener() {
+              @Override public void onEmojiBackspaceClicked(final View v) {
+                Log.d(TAG, "Clicked on Backspace");
+              }
+            })
+            .setOnEmojiClickedListener(new OnEmojiClickedListener() {
+              @Override public void onEmojiClicked(final Emoji emoji) {
+                Log.d(TAG, "Clicked on emoji");
+              }
+            })
+            .setOnEmojiPopupShownListener(new OnEmojiPopupShownListener() {
+              @Override public void onEmojiPopupShown() {
+                emojiButton.setImageResource(R.drawable.ic_keyboard);
+              }
+            })
+            .setOnSoftKeyboardOpenListener(new OnSoftKeyboardOpenListener() {
+              @Override public void onKeyboardOpen(final int keyBoardHeight) {
+                Log.d(TAG, "Opened soft keyboard");
+              }
+            })
+            .setOnEmojiPopupDismissListener(new OnEmojiPopupDismissListener() {
+              @Override public void onEmojiPopupDismiss() {
+                emojiButton.setImageResource(R.drawable.emoji_ios_category_people);
+              }
+            })
+            .setOnSoftKeyboardCloseListener(new OnSoftKeyboardCloseListener() {
+              @Override
+              public void onKeyboardClose() {
+                emojiPopup.dismiss();
+              }
+            })
+            .build(editText);
+  }
+}

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
@@ -126,9 +126,8 @@ public class MainDialog extends DialogFragment {
               }
             })
             .setOnSoftKeyboardCloseListener(new OnSoftKeyboardCloseListener() {
-              @Override
-              public void onKeyboardClose() {
-                emojiPopup.dismiss();
+              @Override public void onKeyboardClose() {
+                Log.d(TAG, "Closed soft keyboard");
               }
             })
             .build(editText);

--- a/app/src/main/res/drawable/ic_message.xml
+++ b/app/src/main/res/drawable/ic_message.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM18,14L6,14v-2h12v2zM18,11L6,11L6,9h12v2zM18,8L6,8L6,6h12v2z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -1,31 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:id="@+id/main_activity_root_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                tools:context=".MainActivity">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:id="@+id/main_dialog_root_view"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              tools:context=".MainDialog">
 
     <android.support.v7.widget.RecyclerView
-        android:id="@+id/main_activity_recycler_view"
+        android:id="@+id/main_dialog_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/main_activity_emoji_bar"/>
+        android:layout_height="200dp"/>
 
     <LinearLayout
-        android:id="@+id/main_activity_emoji_bar"
+        android:id="@+id/main_dialog_emoji_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
         android:background="#FFF"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:padding="4dp">
 
         <ImageButton
-            android:id="@+id/main_activity_emoji"
+            android:id="@+id/main_dialog_emoji"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:background="?attr/selectableItemBackgroundBorderless"
@@ -35,7 +33,7 @@
             tools:ignore="ContentDescription"/>
 
         <com.vanniktech.emoji.EmojiEditText
-            android:id="@+id/main_activity_chat_bottom_message_edittext"
+            android:id="@+id/main_dialog_chat_bottom_message_edittext"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -45,7 +43,7 @@
             app:emojiSize="26sp"/>
 
         <ImageView
-            android:id="@+id/main_activity_send"
+            android:id="@+id/main_dialog_send"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:background="?attr/selectableItemBackgroundBorderless"
@@ -54,4 +52,4 @@
             app:srcCompat="@drawable/ic_send"
             tools:ignore="ContentDescription"/>
     </LinearLayout>
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/activity_main.xml
+++ b/app/src/main/res/menu/activity_main.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/show_dialog"
+        android:icon="@drawable/ic_message"
+        android:title="@string/show_dialog_title"
+        app:showAsAction="ifRoom"/>
     <item
         android:id="@+id/menu_search_option"
         android:icon="@drawable/ic_swap"
@@ -10,13 +15,13 @@
             <group>
                 <item
                     android:id="@+id/variantIos"
-                    android:title="@string/variant_ios_title" />
+                    android:title="@string/variant_ios_title"/>
                 <item
                     android:id="@+id/variantGoogle"
-                    android:title="@string/variant_google_title" />
+                    android:title="@string/variant_google_title"/>
                 <item
                     android:id="@+id/variantEmojiOne"
-                    android:title="@string/variant_emojione_title" />
+                    android:title="@string/variant_emojione_title"/>
             </group>
         </menu>
     </item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="variant_ios_title">Ios</string>
     <string name="variant_google_title">Google</string>
     <string name="variant_emojione_title">EmojiOne</string>
+    <string name="show_dialog_title">Show Dialog</string>
 </resources>

--- a/code_quality_tools/findbugs-filter.xml
+++ b/code_quality_tools/findbugs-filter.xml
@@ -44,4 +44,10 @@
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
     </Match>
 
+    <!-- Sample app. -->
+    <Match>
+        <Class name="~.*MainDialog*.*"/>
+        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+    </Match>
+
 </FindBugsFilter>

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -3,6 +3,7 @@ package com.vanniktech.emoji;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.support.annotation.CheckResult;
@@ -173,7 +174,10 @@ public final class EmojiPopup {
   }
 
   void showAtBottom() {
-    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, 0, Utils.screenHeight(context));
+    final Point desiredLocation = new Point(0, Utils.screenHeight(context) - popupWindow.getHeight());
+
+    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
+    Utils.fixPopupLocation(popupWindow, desiredLocation);
 
     if (onEmojiPopupShownListener != null) {
       onEmojiPopupShownListener.onEmojiPopupShown();

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -72,6 +72,9 @@ public final class EmojiPopup {
           if (onSoftKeyboardCloseListener != null) {
             onSoftKeyboardCloseListener.onKeyboardClose();
           }
+
+          dismiss();
+          Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(), onGlobalLayoutListener);
         }
       }
     }
@@ -162,7 +165,6 @@ public final class EmojiPopup {
   }
 
   public void dismiss() {
-    Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(), onGlobalLayoutListener);
     popupWindow.dismiss();
     variantPopup.dismiss();
     recentEmoji.persist();

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -137,6 +137,8 @@ public final class EmojiPopup {
 
   public void toggle() {
     if (!popupWindow.isShowing()) {
+      // Remove any previous listeners to avoid duplicates.
+      Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(), onGlobalLayoutListener);
       context.getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
 
       if (isKeyboardOpen) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -1,19 +1,16 @@
 package com.vanniktech.emoji;
 
+import android.app.Activity;
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
-import android.os.Build;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewTreeObserver;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupWindow;
 import com.vanniktech.emoji.emoji.Emoji;
@@ -30,15 +27,14 @@ public final class EmojiPopup {
   private static final int MIN_KEYBOARD_HEIGHT = 100;
 
   final View rootView;
-  final Context context;
+  final Activity context;
 
   @NonNull final RecentEmoji recentEmoji;
   @NonNull final EmojiVariantPopup variantPopup;
 
   final PopupWindow popupWindow;
-  private final EmojiEditText emojiEditText;
+  final EmojiEditText emojiEditText;
 
-  int keyBoardHeight;
   boolean isPendingOpen;
   boolean isKeyboardOpen;
 
@@ -46,27 +42,21 @@ public final class EmojiPopup {
   @Nullable OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
   @Nullable OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
 
+  @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+  @Nullable OnEmojiClickedListener onEmojiClickedListener;
+  @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
+
   private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
     @Override public void onGlobalLayout() {
-      final Rect rect = new Rect();
-      rootView.getWindowVisibleDisplayFrame(rect);
+      final Rect rect = Utils.windowVisibleDisplayFrame(context);
+      final int heightDifference = Utils.screenHeight(context) - rect.bottom;
 
-      int heightDifference = getUsableScreenHeight() - (rect.bottom - rect.top);
-
-      final Resources resources = context.getResources();
-      final int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
-
-      if (resourceId > 0) {
-        heightDifference -= resources.getDimensionPixelSize(resourceId);
-      }
-
-      if (heightDifference > MIN_KEYBOARD_HEIGHT) {
-        keyBoardHeight = heightDifference;
-        popupWindow.setWidth(WindowManager.LayoutParams.MATCH_PARENT);
-        popupWindow.setHeight(keyBoardHeight);
+      if (heightDifference > Utils.dpToPx(context, MIN_KEYBOARD_HEIGHT)) {
+        popupWindow.setHeight(heightDifference);
+        popupWindow.setWidth(rect.right);
 
         if (!isKeyboardOpen && onSoftKeyboardOpenListener != null) {
-          onSoftKeyboardOpenListener.onKeyboardOpen(keyBoardHeight);
+          onSoftKeyboardOpenListener.onKeyboardOpen(heightDifference);
         }
 
         isKeyboardOpen = true;
@@ -87,18 +77,13 @@ public final class EmojiPopup {
     }
   };
 
-  @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
-  @Nullable OnEmojiClickedListener onEmojiClickedListener;
-  @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
-
   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditText emojiEditText, @Nullable final RecentEmoji recent) {
-    this.context = rootView.getContext();
-    this.rootView = rootView;
+    this.context = (Activity) rootView.getContext();
+    this.rootView = rootView.getRootView();
     this.emojiEditText = emojiEditText;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);
 
     popupWindow = new PopupWindow(context);
-    popupWindow.setBackgroundDrawable(new BitmapDrawable(context.getResources(), (Bitmap) null)); // To avoid borders & overdraw
 
     final OnEmojiLongClickedListener longClickListener = new OnEmojiLongClickedListener() {
       @Override
@@ -121,7 +106,7 @@ public final class EmojiPopup {
       }
     };
 
-    variantPopup = new EmojiVariantPopup(clickListener);
+    variantPopup = new EmojiVariantPopup(this.rootView, clickListener);
 
     final EmojiView emojiView = new EmojiView(context, clickListener, longClickListener, recentEmoji);
 
@@ -136,9 +121,8 @@ public final class EmojiPopup {
     });
 
     popupWindow.setContentView(emojiView);
-    popupWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-    popupWindow.setWidth(WindowManager.LayoutParams.MATCH_PARENT);
-    popupWindow.setHeight((int) context.getResources().getDimension(R.dimen.emoji_keyboard_height));
+    popupWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NOT_NEEDED);
+    popupWindow.setBackgroundDrawable(new BitmapDrawable(context.getResources(), (Bitmap) null)); // To avoid borders and overdraw.
     popupWindow.setOnDismissListener(new PopupWindow.OnDismissListener() {
       @Override public void onDismiss() {
         if (onEmojiPopupDismissListener != null) {
@@ -148,27 +132,15 @@ public final class EmojiPopup {
     });
   }
 
-  void showAtBottom() {
-    popupWindow.showAtLocation(rootView, Gravity.BOTTOM, 0, 0);
-  }
-
-  private void showAtBottomPending() {
-    if (isKeyboardOpen) {
-      showAtBottom();
-    } else {
-      isPendingOpen = true;
-    }
-  }
-
   public void toggle() {
     if (!popupWindow.isShowing()) {
-      rootView.getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
+      context.getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
 
       if (isKeyboardOpen) {
-        // If keyboard is visible, simply show the emoji popup
+        // If the keyboard is visible, simply show the emoji popup.
         showAtBottom();
       } else {
-        // Open the text keyboard first and immediately after that show the emoji popup
+        // Open the text keyboard first and immediately after that show the emoji popup.
         emojiEditText.setFocusableInTouchMode(true);
         emojiEditText.requestFocus();
 
@@ -177,16 +149,12 @@ public final class EmojiPopup {
         final InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
         inputMethodManager.showSoftInput(emojiEditText, InputMethodManager.SHOW_IMPLICIT);
       }
-
-      if (onEmojiPopupShownListener != null) {
-        onEmojiPopupShownListener.onEmojiPopupShown();
-      }
     } else {
       dismiss();
     }
 
     // Manually dispatch the event. In some cases this does not work out of the box reliably.
-    rootView.getViewTreeObserver().dispatchOnGlobalLayout();
+    context.getWindow().getDecorView().getViewTreeObserver().dispatchOnGlobalLayout();
   }
 
   public boolean isShowing() {
@@ -194,22 +162,25 @@ public final class EmojiPopup {
   }
 
   public void dismiss() {
-    Utils.removeOnGlobalLayoutListener(rootView, onGlobalLayoutListener);
+    Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(), onGlobalLayoutListener);
     popupWindow.dismiss();
     variantPopup.dismiss();
     recentEmoji.persist();
   }
 
-  int getUsableScreenHeight() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      final DisplayMetrics metrics = new DisplayMetrics();
+  void showAtBottom() {
+    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, 0, Utils.screenHeight(context));
 
-      final WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-      windowManager.getDefaultDisplay().getMetrics(metrics);
+    if (onEmojiPopupShownListener != null) {
+      onEmojiPopupShownListener.onEmojiPopupShown();
+    }
+  }
 
-      return metrics.heightPixels;
+  private void showAtBottomPending() {
+    if (isKeyboardOpen) {
+      showAtBottom();
     } else {
-      return rootView.getRootView().getHeight();
+      isPendingOpen = true;
     }
   }
 
@@ -224,13 +195,13 @@ public final class EmojiPopup {
     @Nullable private RecentEmoji recentEmoji;
 
     private Builder(final View rootView) {
-      this.rootView = checkNotNull(rootView, "The rootView can't be null");
+      this.rootView = checkNotNull(rootView, "The root View can't be null");
     }
 
     /**
-     * @param rootView the rootView of your layout.xml which will be used for calculating the height
-     * of the keyboard
-     * @return builder for building {@link EmojiPopup}
+     * @param rootView The root View of your layout.xml which will be used for calculating the height
+     *                 of the keyboard.
+     * @return builder For building the {@link EmojiPopup}.
      */
     @CheckResult public static Builder fromRootView(final View rootView) {
       return new Builder(rootView);
@@ -267,7 +238,7 @@ public final class EmojiPopup {
     }
 
     /**
-     * allows you to pass your own implementation of recent emojis. If not provided the default one
+     * Allows you to pass your own implementation of recent emojis. If not provided the default one
      * {@link RecentEmojiManager} will be used
      *
      * @since 0.2.0

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -82,7 +82,7 @@ public final class EmojiPopup {
   };
 
   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditText emojiEditText, @Nullable final RecentEmoji recent) {
-    this.context = Utils.contextToActivity(rootView.getContext());
+    this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
     this.emojiEditText = emojiEditText;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -82,7 +82,7 @@ public final class EmojiPopup {
   };
 
   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditText emojiEditText, @Nullable final RecentEmoji recent) {
-    this.context = (Activity) rootView.getContext();
+    this.context = Utils.contextToActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
     this.emojiEditText = emojiEditText;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
@@ -1,7 +1,8 @@
 package com.vanniktech.emoji;
 
-import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -21,38 +22,82 @@ import static android.view.View.MeasureSpec.makeMeasureSpec;
 
 final class EmojiVariantPopup {
   private static final int MARGIN = 2;
+  private static final int DONT_UPDATE_FLAG = -1;
 
+  @NonNull private final View rootView;
   @Nullable private final OnEmojiClickedListener listener;
 
-  private PopupWindow popupWindow;
+  @Nullable private PopupWindow popupWindow;
 
-  EmojiVariantPopup(@Nullable final OnEmojiClickedListener listener) {
+  EmojiVariantPopup(@NonNull final View rootView, @Nullable final OnEmojiClickedListener listener) {
+    this.rootView = rootView;
     this.listener = listener;
   }
 
   void show(@NonNull final View clickedImage, @NonNull final Emoji emoji) {
     dismiss();
 
-    final View content = View.inflate(clickedImage.getContext(), R.layout.emoji_skin_popup, null);
-    final LinearLayout imageContainer = (LinearLayout) content.findViewById(R.id.container);
+    final View content = initView(clickedImage.getContext(), emoji, clickedImage.getWidth());
 
-    popupWindow = new PopupWindow(content,
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT
-    );
+    popupWindow = new PopupWindow(content, WindowManager.LayoutParams.WRAP_CONTENT, WindowManager.LayoutParams.WRAP_CONTENT);
+    popupWindow.setFocusable(true);
+    popupWindow.setOutsideTouchable(true);
+    popupWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NOT_NEEDED);
+    popupWindow.setBackgroundDrawable(new BitmapDrawable(clickedImage.getContext().getResources(), (Bitmap) null));
+
+    content.measure(makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+
+    final Point location = Utils.locationOnScreen(clickedImage);
+
+    final int x = location.x - content.getMeasuredWidth() / 2 + clickedImage.getWidth() / 2;
+    final int y = location.y - content.getMeasuredHeight();
+
+    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, x, y);
+
+    content.post(new Runnable() {
+      @Override public void run() {
+        final Point actualLocation = Utils.locationOnScreen(content);
+
+        // If the actual location the popup is shown at differs from the wanted (Can happen with
+        // dialogs), we have to fix it.
+        if (!(actualLocation.x == x && actualLocation.y == y)) {
+          final int differenceX = actualLocation.x - x;
+          final int differenceY = actualLocation.y - y;
+
+          final int fixedOffsetX = actualLocation.x > x ? x - differenceX : x + differenceX;
+          final int fixedOffsetY = actualLocation.y > y ? y - differenceY : y + differenceY;
+
+          popupWindow.update(fixedOffsetX, fixedOffsetY, DONT_UPDATE_FLAG, DONT_UPDATE_FLAG);
+        }
+
+        content.requestFocus();
+      }
+    });
+  }
+
+  void dismiss() {
+    if (popupWindow != null) {
+      popupWindow.dismiss();
+      popupWindow = null;
+    }
+  }
+
+  private View initView(@NonNull final Context context, @NonNull final Emoji emoji, final int width) {
+    final View result = View.inflate(context, R.layout.emoji_skin_popup, null);
+    final LinearLayout imageContainer = (LinearLayout) result.findViewById(R.id.container);
 
     final List<Emoji> variants = emoji.getBase().getVariants();
     variants.add(0, emoji.getBase());
 
-    final LayoutInflater inflater = LayoutInflater.from(clickedImage.getContext());
+    final LayoutInflater inflater = LayoutInflater.from(context);
 
     for (final Emoji variant : variants) {
       final ImageView emojiImage = (ImageView) inflater.inflate(R.layout.emoji_item, imageContainer, false);
       final ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) emojiImage.getLayoutParams();
-      final int margin = Utils.dpToPx(clickedImage.getContext(), MARGIN);
+      final int margin = Utils.dpToPx(context, MARGIN);
 
       // Use the same size for Emojis as in the picker.
-      layoutParams.width = clickedImage.getWidth();
+      layoutParams.width = width;
       layoutParams.setMargins(margin, margin, margin, margin);
       emojiImage.setImageResource(variant.getResource());
 
@@ -68,25 +113,6 @@ final class EmojiVariantPopup {
       imageContainer.addView(emojiImage);
     }
 
-    content.measure(makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
-
-    popupWindow.setOutsideTouchable(true);
-    popupWindow.setBackgroundDrawable(new BitmapDrawable(clickedImage.getContext().getResources(), (Bitmap) null));
-
-    final int[] location = new int[2];
-    clickedImage.getLocationOnScreen(location);
-
-    final int x = location[0] - popupWindow.getContentView().getMeasuredWidth() / 2 + clickedImage.getWidth() / 2;
-    final int y = location[1] - popupWindow.getContentView().getMeasuredHeight();
-
-    popupWindow.showAtLocation(((Activity) content.getContext()).getWindow().getDecorView(),
-            Gravity.NO_GRAVITY, x, y);
-  }
-
-  void dismiss() {
-    if (popupWindow != null) {
-      popupWindow.dismiss();
-      popupWindow = null;
-    }
+    return result;
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
@@ -22,7 +22,6 @@ import static android.view.View.MeasureSpec.makeMeasureSpec;
 
 final class EmojiVariantPopup {
   private static final int MARGIN = 2;
-  private static final int DONT_UPDATE_FLAG = -1;
 
   @NonNull private final View rootView;
   @Nullable private final OnEmojiClickedListener listener;
@@ -48,29 +47,13 @@ final class EmojiVariantPopup {
     content.measure(makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED), makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
 
     final Point location = Utils.locationOnScreen(clickedImage);
+    final Point desiredLocation = new Point(
+            location.x - content.getMeasuredWidth() / 2 + clickedImage.getWidth() / 2,
+            location.y - content.getMeasuredHeight()
+    );
 
-    final int x = location.x - content.getMeasuredWidth() / 2 + clickedImage.getWidth() / 2;
-    final int y = location.y - content.getMeasuredHeight();
-
-    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, x, y);
-
-    content.post(new Runnable() {
-      @Override public void run() {
-        final Point actualLocation = Utils.locationOnScreen(content);
-
-        // If the actual location the popup is shown at differs from the wanted (Can happen with
-        // dialogs), we have to fix it.
-        if (!(actualLocation.x == x && actualLocation.y == y)) {
-          final int differenceX = actualLocation.x - x;
-          final int differenceY = actualLocation.y - y;
-
-          final int fixedOffsetX = actualLocation.x > x ? x - differenceX : x + differenceX;
-          final int fixedOffsetY = actualLocation.y > y ? y - differenceY : y + differenceY;
-
-          popupWindow.update(fixedOffsetX, fixedOffsetY, DONT_UPDATE_FLAG, DONT_UPDATE_FLAG);
-        }
-      }
-    });
+    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
+    Utils.fixPopupLocation(popupWindow, desiredLocation);
   }
 
   void dismiss() {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
@@ -69,8 +69,6 @@ final class EmojiVariantPopup {
 
           popupWindow.update(fixedOffsetX, fixedOffsetY, DONT_UPDATE_FLAG, DONT_UPDATE_FLAG);
         }
-
-        content.requestFocus();
       }
     });
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -3,6 +3,7 @@ package com.vanniktech.emoji;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
@@ -60,6 +61,20 @@ final class Utils {
     context.getWindow().getDecorView().getWindowVisibleDisplayFrame(result);
 
     return result;
+  }
+
+  static Activity contextToActivity(@NonNull final Context context) {
+    Context result = context;
+
+    while(result instanceof ContextWrapper){
+      if(result instanceof Activity){
+        return (Activity) context;
+      }
+
+      result = ((ContextWrapper) context).getBaseContext();
+    }
+
+    throw new IllegalArgumentException("The passed Context is not an Activity");
   }
 
   static void fixPopupLocation(@NonNull final PopupWindow popupWindow, @NonNull final Point desiredLocation) {

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -63,7 +63,7 @@ final class Utils {
     return result;
   }
 
-  static Activity contextToActivity(@NonNull final Context context) {
+  static Activity asActivity(@NonNull final Context context) {
     Context result = context;
 
     while (result instanceof ContextWrapper) {

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -1,7 +1,10 @@
 package com.vanniktech.emoji;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
@@ -28,8 +31,32 @@ final class Utils {
     return reference;
   }
 
-  public static int dpToPx(final Context context, final float dp) {
+  static int dpToPx(@NonNull final Context context, final float dp) {
     return (int) (dp * context.getResources().getDisplayMetrics().density);
+  }
+
+  static int screenHeight(@NonNull final Activity context) {
+    final Point size = new Point();
+
+    context.getWindowManager().getDefaultDisplay().getSize(size);
+
+    return size.y;
+  }
+
+  @NonNull static Point locationOnScreen(@NonNull final View view) {
+    final int[] location = new int[2];
+
+    view.getLocationOnScreen(location);
+
+    return new Point(location[0], location[1]);
+  }
+
+  @NonNull static Rect windowVisibleDisplayFrame(@NonNull final Activity context) {
+    final Rect result = new Rect();
+
+    context.getWindow().getDecorView().getWindowVisibleDisplayFrame(result);
+
+    return result;
   }
 
   private Utils() {

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -66,8 +66,8 @@ final class Utils {
   static Activity contextToActivity(@NonNull final Context context) {
     Context result = context;
 
-    while(result instanceof ContextWrapper){
-      if(result instanceof Activity){
+    while (result instanceof ContextWrapper) {
+      if (result instanceof Activity) {
         return (Activity) context;
       }
 
@@ -89,15 +89,15 @@ final class Utils {
           final int fixedOffsetX;
           final int fixedOffsetY;
 
-          if (actualLocation.x > desiredLocation.x)
-              fixedOffsetX = desiredLocation.x - differenceX;
-          else {
+          if (actualLocation.x > desiredLocation.x) {
+            fixedOffsetX = desiredLocation.x - differenceX;
+          } else {
               fixedOffsetX = desiredLocation.x + differenceX;
           }
 
-          if (actualLocation.y > desiredLocation.y)
-              fixedOffsetY = desiredLocation.y - differenceY;
-          else {
+          if (actualLocation.y > desiredLocation.y) {
+            fixedOffsetY = desiredLocation.y - differenceY;
+          } else {
               fixedOffsetY = desiredLocation.y + differenceY;
           }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -9,11 +9,14 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.widget.PopupWindow;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 
 final class Utils {
+  private static final int DONT_UPDATE_FLAG = -1;
+
   @TargetApi(JELLY_BEAN) static void removeOnGlobalLayoutListener(final View v, final ViewTreeObserver.OnGlobalLayoutListener listener) {
     if (SDK_INT < JELLY_BEAN) {
       //noinspection deprecation
@@ -57,6 +60,36 @@ final class Utils {
     context.getWindow().getDecorView().getWindowVisibleDisplayFrame(result);
 
     return result;
+  }
+
+  static void fixPopupLocation(@NonNull final PopupWindow popupWindow, @NonNull final Point desiredLocation) {
+    popupWindow.getContentView().post(new Runnable() {
+      @Override public void run() {
+        final Point actualLocation = Utils.locationOnScreen(popupWindow.getContentView());
+
+        if (!(actualLocation.x == desiredLocation.x && actualLocation.y == desiredLocation.y)) {
+          final int differenceX = actualLocation.x - desiredLocation.x;
+          final int differenceY = actualLocation.y - desiredLocation.y;
+
+          final int fixedOffsetX;
+          final int fixedOffsetY;
+
+          if (actualLocation.x > desiredLocation.x)
+              fixedOffsetX = desiredLocation.x - differenceX;
+          else {
+              fixedOffsetX = desiredLocation.x + differenceX;
+          }
+
+          if (actualLocation.y > desiredLocation.y)
+              fixedOffsetY = desiredLocation.y - differenceY;
+          else {
+              fixedOffsetY = desiredLocation.y + differenceY;
+          }
+
+          popupWindow.update(fixedOffsetX, fixedOffsetY, DONT_UPDATE_FLAG, DONT_UPDATE_FLAG);
+        }
+      }
+    });
   }
 
   private Utils() {

--- a/emoji/src/main/res/values/dimens.xml
+++ b/emoji/src/main/res/values/dimens.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="emoji_keyboard_height">250dp</dimen>
     <dimen name="emoji_grid_view_column_width">36dp</dimen>
     <dimen name="emoji_grid_view_spacing">6dp</dimen>
 </resources>


### PR DESCRIPTION
This would address some of the points in #96 and fix #26.

### Contents of this Pull Request

The internal popup logic has been improved in several ways:

- Support for dialogs and other places apart from a normal `Activity`.
- Better behaviour of variant popups. If the user opens one and clicks outside of it, the event is not delegated, but only the popup is closed.
- Better keyboard height detection
- Fixes for identification if the keyboard is open or not. Previously, when one opened the picker, clicked the toggle item and closed the keyboard by pressing the back button, two clicks were required to open the popup again, as the `EmojiPopup` had a wrong state concerning `isKeyboardOpen`. 
- The `onEmojiPopupShownListener` is only shown, after the popup is really shown. Previously it was called, when we started opening the keyboard, which could lead to a wrong state if it was not shown (If a hardware keyboard is present for example).

#### Code changes to achive this

- The height of the current `rootView` is calculated from the `DecorView`.
- Better places for setting and removing the global layout listener were chosen.
- The popup is always shown at the bottom of the screen, following the advice in #26.
- `popupWindow.setFocusable(true)` is now called on the variant popup. `popupWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NOT_NEEDED)` was the key to make that work without weird side effects.
- Adjusted location calculation for the variant popup, to make it work in dialogs.

I have added a simple Dialog to the sample for showcasing and testing.

#### Things concerning backwards compability

- The popup now closes itself when the keyboard is closed. Thus, a call to `emojiPopup.dismiss();` in `onKeyboardClose` is not necessary anymore.
- We require the `Context` of the `rootView` to be an `Activity` now. We need that as we want to access the `Window` for better height calculation.