### PR TITLE
Better emoji height management

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         android:id="@+id/main_activity_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/main_activity_emoji_bar" />
+        android:layout_above="@+id/main_activity_emoji_bar"/>
 
     <LinearLayout
         android:id="@+id/main_activity_emoji_bar"
@@ -32,7 +32,7 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/emoji_ios_category_people"
-            tools:ignore="ContentDescription" />
+            tools:ignore="ContentDescription"/>
 
         <com.vanniktech.emoji.EmojiEditText
             android:id="@+id/main_activity_chat_bottom_message_edittext"
@@ -41,7 +41,7 @@
             android:layout_weight="1"
             android:imeOptions="actionSend"
             android:inputType="textCapSentences|textMultiLine"
-            android:maxLines="3" />
+            android:maxLines="3"/>
 
         <ImageView
             android:id="@+id/main_activity_send"
@@ -51,6 +51,6 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/ic_send"
-            tools:ignore="ContentDescription" />
+            tools:ignore="ContentDescription"/>
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main_activity_root_view"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".MainActivity">
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:id="@+id/main_activity_root_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                tools:context=".MainActivity">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_activity_recycler_view"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:id="@+id/main_activity_root_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                tools:context=".MainActivity">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_activity_root_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".MainActivity">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_activity_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/main_activity_emoji_bar"/>
+        android:layout_above="@+id/main_activity_emoji_bar" />
 
     <LinearLayout
         android:id="@+id/main_activity_emoji_bar"
@@ -32,7 +32,7 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/emoji_ios_category_people"
-            tools:ignore="ContentDescription"/>
+            tools:ignore="ContentDescription" />
 
         <com.vanniktech.emoji.EmojiEditText
             android:id="@+id/main_activity_chat_bottom_message_edittext"
@@ -41,8 +41,7 @@
             android:layout_weight="1"
             android:imeOptions="actionSend"
             android:inputType="textCapSentences|textMultiLine"
-            android:maxLines="3"
-            app:emojiSize="26sp"/>
+            android:maxLines="3" />
 
         <ImageView
             android:id="@+id/main_activity_send"
@@ -52,6 +51,6 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/ic_send"
-            tools:ignore="ContentDescription"/>
+            tools:ignore="ContentDescription" />
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/adapter_chat.xml
+++ b/app/src/main/res/layout/adapter_chat.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
 
     <com.vanniktech.emoji.EmojiTextView
         android:id="@+id/adapter_chat_text_view"
@@ -11,5 +11,6 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
         android:textIsSelectable="true"
-        tools:text="my text"/>
+        tools:text="my text"
+        />
 </LinearLayout>

--- a/app/src/main/res/layout/adapter_chat.xml
+++ b/app/src/main/res/layout/adapter_chat.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    >
 
   <com.vanniktech.emoji.EmojiTextView
       android:id="@+id/adapter_chat_text_view"

--- a/app/src/main/res/layout/adapter_chat.xml
+++ b/app/src/main/res/layout/adapter_chat.xml
@@ -3,14 +3,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    >
+    android:orientation="vertical">
 
-  <com.vanniktech.emoji.EmojiTextView
-      android:id="@+id/adapter_chat_text_view"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:textIsSelectable="true"
-      tools:text="my text"
-      />
+    <com.vanniktech.emoji.EmojiTextView
+        android:id="@+id/adapter_chat_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+        android:textIsSelectable="true"
+        tools:text="my text" />
 </LinearLayout>

--- a/app/src/main/res/layout/adapter_chat.xml
+++ b/app/src/main/res/layout/adapter_chat.xml
@@ -11,5 +11,5 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
         android:textIsSelectable="true"
-        tools:text="my text" />
+        tools:text="my text"/>
 </LinearLayout>

--- a/app/src/main/res/layout/adapter_chat.xml
+++ b/app/src/main/res/layout/adapter_chat.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.vanniktech.emoji.EmojiTextView
-        android:id="@+id/adapter_chat_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large"
-        android:textIsSelectable="true"
-        tools:text="my text"
-        />
+  <com.vanniktech.emoji.EmojiTextView
+      android:id="@+id/adapter_chat_text_view"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textAppearance="@style/TextAppearance.AppCompat.Large"
+      android:textIsSelectable="true"
+      tools:text="my text"
+      />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:id="@+id/main_dialog_root_view"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              tools:context=".MainDialog">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_dialog_root_view"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    tools:context=".MainDialog">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_dialog_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="200dp"/>
+        android:layout_height="200dp" />
 
     <LinearLayout
         android:id="@+id/main_dialog_emoji_bar"
@@ -30,7 +30,7 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/emoji_ios_category_people"
-            tools:ignore="ContentDescription"/>
+            tools:ignore="ContentDescription" />
 
         <com.vanniktech.emoji.EmojiEditText
             android:id="@+id/main_dialog_chat_bottom_message_edittext"
@@ -39,8 +39,7 @@
             android:layout_weight="1"
             android:imeOptions="actionSend"
             android:inputType="textCapSentences|textMultiLine"
-            android:maxLines="3"
-            app:emojiSize="26sp"/>
+            android:maxLines="3" />
 
         <ImageView
             android:id="@+id/main_dialog_send"
@@ -50,6 +49,6 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/ic_send"
-            tools:ignore="ContentDescription"/>
+            tools:ignore="ContentDescription" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -11,7 +11,7 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_dialog_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="200dp" />
+        android:layout_height="200dp"/>
 
     <LinearLayout
         android:id="@+id/main_dialog_emoji_bar"
@@ -30,7 +30,7 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/emoji_ios_category_people"
-            tools:ignore="ContentDescription" />
+            tools:ignore="ContentDescription"/>
 
         <com.vanniktech.emoji.EmojiEditText
             android:id="@+id/main_dialog_chat_bottom_message_edittext"
@@ -39,7 +39,7 @@
             android:layout_weight="1"
             android:imeOptions="actionSend"
             android:inputType="textCapSentences|textMultiLine"
-            android:maxLines="3" />
+            android:maxLines="3"/>
 
         <ImageView
             android:id="@+id/main_dialog_send"
@@ -49,6 +49,6 @@
             android:padding="12dp"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/ic_send"
-            tools:ignore="ContentDescription" />
+            tools:ignore="ContentDescription"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main_dialog_root_view"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    tools:context=".MainDialog">
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:id="@+id/main_dialog_root_view"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              tools:context=".MainDialog">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_dialog_recycler_view"

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -1,40 +1,25 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
-import android.content.res.TypedArray;
-import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import com.vanniktech.emoji.emoji.Emoji;
 
 public class EmojiEditText extends AppCompatEditText {
-  private int emojiSize;
-
   public EmojiEditText(final Context context) {
     this(context, null);
   }
 
   public EmojiEditText(final Context context, final AttributeSet attrs) {
     super(context, attrs);
-    init(attrs);
+
+    init();
   }
 
-  private void init(@Nullable final AttributeSet attrs) {
+  private void init() {
     if (!isInEditMode()) {
       EmojiManager.getInstance().verifyInstalled();
-    }
-
-    if (attrs == null) {
-      emojiSize = (int) getTextSize();
-    } else {
-      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
-
-      try {
-        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getTextSize());
-      } finally {
-        a.recycle();
-      }
     }
 
     setText(getText());
@@ -42,11 +27,7 @@ public class EmojiEditText extends AppCompatEditText {
 
   @Override
   protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
-    EmojiHandler.addEmojis(getContext(), getText(), emojiSize);
-  }
-
-  public void setEmojiSize(final int pixels) {
-    emojiSize = pixels;
+    EmojiHandler.addEmojis(getContext(), getText(), getLineHeight());
   }
 
   public void backspace() {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -1,6 +1,7 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
+import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
@@ -29,5 +30,10 @@ final class EmojiSpan extends DynamicDrawableSpan {
     }
 
     return drawable;
+  }
+
+  @Override public int getSize(final Paint paint, final CharSequence text, final int start,
+                               final int end, final Paint.FontMetricsInt fm) {
+    return size;
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
@@ -1,39 +1,24 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
-import android.content.res.TypedArray;
-import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatTextView;
 import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 
 public class EmojiTextView extends AppCompatTextView {
-  private int emojiSize;
-
   public EmojiTextView(final Context context) {
     this(context, null);
   }
 
   public EmojiTextView(final Context context, final AttributeSet attrs) {
     super(context, attrs);
-    init(attrs);
+
+    init();
   }
 
-  private void init(@Nullable final AttributeSet attrs) {
+  private void init() {
     if (!isInEditMode()) {
       EmojiManager.getInstance().verifyInstalled();
-    }
-
-    if (attrs == null) {
-      emojiSize = (int) getTextSize();
-    } else {
-      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
-
-      try {
-        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getTextSize());
-      } finally {
-        a.recycle();
-      }
     }
 
     setText(getText());
@@ -42,11 +27,7 @@ public class EmojiTextView extends AppCompatTextView {
   @Override public void setText(final CharSequence rawText, final BufferType type) {
     final CharSequence text = rawText == null ? "" : rawText;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
-    EmojiHandler.addEmojis(getContext(), spannableStringBuilder, emojiSize);
+    EmojiHandler.addEmojis(getContext(), spannableStringBuilder, getLineHeight());
     super.setText(spannableStringBuilder, type);
-  }
-
-  public void setEmojiSize(final int pixels) {
-    emojiSize = pixels;
   }
 }

--- a/emoji/src/main/res/values/attrs.xml
+++ b/emoji/src/main/res/values/attrs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <declare-styleable name="emoji">
-        <attr name="emojiSize" format="dimension"/>
-    </declare-styleable>
-</resources>


### PR DESCRIPTION
This would fix #116.
This change is **not** backwards-compatible.

### Contents of this Pull Request

The `EmojiSpan` now automatically calculates it's size based on the line height of the `TextView` it resides in. This has the advantage that there is no "jumping" when typing and weird visuals as described in #116.
This removes the custom `emojiSize` attr; The user is expected to change text size by the normal methods (`textAppearance` or `textSize`)

| Before | After |
| -- | -- |
| ![device-2017-05-04-235135](https://cloud.githubusercontent.com/assets/8021265/25726625/650a1df2-3125-11e7-9fcb-1f45c406cb76.gif) | ![device-2017-05-04-235323](https://cloud.githubusercontent.com/assets/8021265/25726636/6ea13936-3125-11e7-97f1-1860a01506dc.gif) |

If you look closely, you can see the "jump" at the left GIF.
(Sorry about the bad quality of the GIFs...)

### Code changes to achieve this

- The `EmojiSpan` now gets the `lineHeight` of the `EmojiTextView` or `EmojiEditText` passed as the size. The `getSize` method was overriden to make this work.
- **The custom `emojiSize` attr and all associated methods have been removed.**
- The adapter items now have their `textAppearance` set to `TextAppearance.AppCompat.Large` for showcasing how to change the size.
