### PR TITLE
Add back Emoji Size and use line height as the default.

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
@@ -1,12 +1,16 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.annotation.CallSuper;
+import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatButton;
 import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 
 public class EmojiButton extends AppCompatButton {
+  private int emojiSize;
+
   public EmojiButton(final Context context) {
     this(context, null);
   }
@@ -19,12 +23,29 @@ public class EmojiButton extends AppCompatButton {
     }
 
     setText(getText());
+
+    if (attrs == null) {
+      emojiSize = getLineHeight();
+    } else {
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+
+      try {
+        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+      } finally {
+        a.recycle();
+      }
+    }
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {
     final CharSequence text = rawText == null ? "" : rawText;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
-    EmojiHandler.replaceWithImages(getContext(), spannableStringBuilder, getLineHeight());
+    EmojiHandler.replaceWithImages(getContext(), spannableStringBuilder, emojiSize);
     super.setText(spannableStringBuilder, type);
+  }
+
+  public void setEmojiSize(@Px final int pixels) {
+    emojiSize = pixels;
+    setText(getText()); // Update it.
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -1,13 +1,17 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.annotation.CallSuper;
+import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import com.vanniktech.emoji.emoji.Emoji;
 
 public class EmojiEditText extends AppCompatEditText {
+  private int emojiSize;
+
   public EmojiEditText(final Context context) {
     this(context, null);
   }
@@ -20,10 +24,22 @@ public class EmojiEditText extends AppCompatEditText {
     }
 
     setText(getText());
+
+    if (attrs == null) {
+      emojiSize = getLineHeight();
+    } else {
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+
+      try {
+        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+      } finally {
+        a.recycle();
+      }
+    }
   }
 
   @Override @CallSuper protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
-    EmojiHandler.replaceWithImages(getContext(), getText(), getLineHeight());
+    EmojiHandler.replaceWithImages(getContext(), getText(), emojiSize);
   }
 
   @CallSuper public void backspace() {
@@ -42,5 +58,10 @@ public class EmojiEditText extends AppCompatEditText {
         getText().replace(Math.min(start, end), Math.max(start, end), emoji.getUnicode(), 0, emoji.getUnicode().length());
       }
     }
+  }
+
+  public void setEmojiSize(@Px final int pixels) {
+    emojiSize = pixels;
+    setText(getText()); // Update it.
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
@@ -1,12 +1,16 @@
 package com.vanniktech.emoji;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.annotation.CallSuper;
+import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatTextView;
 import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 
 public class EmojiTextView extends AppCompatTextView {
+  private int emojiSize;
+
   public EmojiTextView(final Context context) {
     this(context, null);
   }
@@ -19,12 +23,29 @@ public class EmojiTextView extends AppCompatTextView {
     }
 
     setText(getText());
+
+    if (attrs == null) {
+      emojiSize = getLineHeight();
+    } else {
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+
+      try {
+        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+      } finally {
+        a.recycle();
+      }
+    }
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {
     final CharSequence text = rawText == null ? "" : rawText;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
-    EmojiHandler.replaceWithImages(getContext(), spannableStringBuilder, getLineHeight());
+    EmojiHandler.replaceWithImages(getContext(), spannableStringBuilder, emojiSize);
     super.setText(spannableStringBuilder, type);
+  }
+
+  public void setEmojiSize(@Px final int pixels) {
+    emojiSize = pixels;
+    setText(getText()); // Update it.
   }
 }

--- a/emoji/src/main/res/values/attrs.xml
+++ b/emoji/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="emoji">
+    <attr name="emojiSize" format="dimension"/>
+  </declare-styleable>
+</resources>


### PR DESCRIPTION
Restores some part of #117 and fixes #121 by allowing to set the emoji size using pixels. 