### PR TITLE
Update generator for latest changes

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -14,7 +14,7 @@ The script does five things:
 
 ## Prerequisites
 
-[NodeJS 7](https://nodejs.org)<br>
+[NodeJS 8](https://nodejs.org)<br>
 [Npm](https://www.npmjs.com/) or [Yarn](https://yarnpkg.com/)
 
 ## Running the script

--- a/generator/index.js
+++ b/generator/index.js
@@ -231,7 +231,8 @@ async function parse() {
         }
 
         const code = row[1].children[0].attribs.name;
-        const isVariant = row[15].children[0].data.includes("skin tone");
+        const name = row[15].children[0].data;
+        const isVariant = name.includes("skin tone");
 
         if (ignore.includes(code)) {
             continue;
@@ -239,6 +240,7 @@ async function parse() {
 
         const emoji = {
             unicode: code,
+            name: name,
             variants: []
         };
 
@@ -253,8 +255,13 @@ async function parse() {
 
         if (isVariant) {
             const array = map.get(category);
+            const base = array.find(it => it.name === name.substring(0, name.indexOf(":")));
 
-            array[array.length - 1].variants.push(emoji);
+            if (base) {
+                base.variants.push(emoji);
+            } else {
+                console.error(`Base not found for variant: ${name}`)
+            }
         } else {
             if (map.has(category)) {
                 map.get(category).push(emoji);

--- a/generator/package.json
+++ b/generator/package.json
@@ -2,7 +2,7 @@
   "name": "emoji-parser",
   "version": "1.0.0",
   "scripts": {
-    "start": "node --harmony-async-await index.js"
+    "start": "node --max-old-space-size=4096 index.js"
   },
   "description": "Parser and extractor of emojis",
   "main": "index.js",
@@ -10,12 +10,12 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^1.0.0-rc.1",
-    "command-line-args": "^4.0.1",
-    "download": "^6.0.0",
+    "command-line-args": "^4.0.6",
+    "download": "^6.2.5",
     "fs-extra": "^3.0.1",
-    "imagemin": "^5.2.2",
+    "imagemin": "^5.3.1",
     "imagemin-optipng": "^5.2.1",
-    "stable": "^0.1.5",
+    "stable": "^0.1.6",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
This updates the `generator` for the latest changes, which are:

- `NodeJs` 8.
- Adjustments for the latest emoji metadata files.
- Latest library versions.

I have also included a flag for a larger heap. The default does not seem to be enough with the latest additions.

There are quite some new emojis, but I haven't included them, because they are [not ordered correctly](https://github.com/emojione/emojione/issues/523) yet.