### PR TITLE
Fix emoji height calculations

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
@@ -2,6 +2,7 @@ package com.vanniktech.emoji;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Paint;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatButton;
@@ -9,7 +10,7 @@ import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 
 public class EmojiButton extends AppCompatButton {
-  private int emojiSize;
+  private float emojiSize;
 
   public EmojiButton(final Context context) {
     this(context, null);
@@ -22,19 +23,22 @@ public class EmojiButton extends AppCompatButton {
       EmojiManager.getInstance().verifyInstalled();
     }
 
-    setText(getText());
+    final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
+    final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
 
     if (attrs == null) {
-      emojiSize = getLineHeight();
+      emojiSize = defaultEmojiSize;
     } else {
-      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.EmojiButton);
 
       try {
-        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+        emojiSize = a.getDimension(R.styleable.EmojiButton_emojiSize, defaultEmojiSize);
       } finally {
         a.recycle();
       }
     }
+
+    setText(getText());
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -2,6 +2,7 @@ package com.vanniktech.emoji;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Paint;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatEditText;
@@ -10,7 +11,7 @@ import android.view.KeyEvent;
 import com.vanniktech.emoji.emoji.Emoji;
 
 public class EmojiEditText extends AppCompatEditText {
-  private int emojiSize;
+  private float emojiSize;
 
   public EmojiEditText(final Context context) {
     this(context, null);
@@ -23,19 +24,22 @@ public class EmojiEditText extends AppCompatEditText {
       EmojiManager.getInstance().verifyInstalled();
     }
 
-    setText(getText());
+    final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
+    final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
 
     if (attrs == null) {
-      emojiSize = getLineHeight();
+      emojiSize = defaultEmojiSize;
     } else {
-      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.EmojiEditText);
 
       try {
-        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+        emojiSize = a.getDimension(R.styleable.EmojiEditText_emojiSize, defaultEmojiSize);
       } finally {
         a.recycle();
       }
     }
+
+    setText(getText());
   }
 
   @Override @CallSuper protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -112,7 +112,7 @@ public final class EmojiManager {
     INSTANCE.emojiRepetitivePattern = null;
   }
 
-  static void replaceWithImages(final Context context, final Spannable text, final int emojiSize) {
+  static void replaceWithImages(final Context context, final Spannable text, final float emojiSize) {
     final EmojiManager emojiManager = EmojiManager.getInstance();
     final EmojiSpan[] existingSpans = text.getSpans(0, text.length(), EmojiSpan.class);
     final List<Integer> existingSpanPositions = new ArrayList<>(existingSpans.length);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
@@ -2,6 +2,7 @@ package com.vanniktech.emoji;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Paint;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Px;
 import android.support.v7.widget.AppCompatTextView;
@@ -9,7 +10,7 @@ import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 
 public class EmojiTextView extends AppCompatTextView {
-  private int emojiSize;
+  private float emojiSize;
 
   public EmojiTextView(final Context context) {
     this(context, null);
@@ -22,19 +23,22 @@ public class EmojiTextView extends AppCompatTextView {
       EmojiManager.getInstance().verifyInstalled();
     }
 
-    setText(getText());
+    final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
+    final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
 
     if (attrs == null) {
-      emojiSize = getLineHeight();
+      emojiSize = defaultEmojiSize;
     } else {
-      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.emoji);
+      final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.EmojiTextView);
 
       try {
-        emojiSize = (int) a.getDimension(R.styleable.emoji_emojiSize, getLineHeight());
+        emojiSize = a.getDimension(R.styleable.EmojiTextView_emojiSize, defaultEmojiSize);
       } finally {
         a.recycle();
       }
     }
+
+    setText(getText());
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {

--- a/emoji/src/main/res/values/attrs.xml
+++ b/emoji/src/main/res/values/attrs.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <declare-styleable name="emoji">
-    <attr name="emojiSize" format="dimension"/>
+  <attr name="emojiSize" format="dimension"/>
+
+  <declare-styleable name="EmojiButton">
+    <attr name="emojiSize"/>
+  </declare-styleable>
+
+  <declare-styleable name="EmojiEditText">
+    <attr name="emojiSize"/>
+  </declare-styleable>
+
+  <declare-styleable name="EmojiTextView">
+    <attr name="emojiSize"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
This fixes the height problems in `EmojiTextView`, `EmojiEditText` and `EmojiButton` once and for all. This should properly fix #116, #120, #121 and maybe #138.

It now looks like this with a `lineSpacingExtra` applied:

![Screenshot](https://user-images.githubusercontent.com/8021265/27766144-fa32a088-5ec6-11e7-9a5b-3434bd3778b5.png)

`emojiSize` still works as expected and the emojis are properly centered now.

### Code changes

- The calculations were changed to now use the `FontMetrics`. Using the `lineHeight` had the problem, that it didn't correctly work when modifying it through `lineSpacingExtra` or `lineSpacingMultiplier` (maybe more). The idea (and most of the implementation) is from [this StackOverflow answer](https://stackoverflow.com/a/38788432/4279995).
- The `EmojiSpan` is now an `ImageSpan`. I noticed an unreproduceable leak showing up sometimes, I think that is related to how the `EmojiSpan` was implemented before. This should be fixed by using the `getDrawable` implementation of the `ImageSpan`.
- I fixed the attr declaration of the `EmojiSpan`, Android Studio was complaining about (A new `declare-styleable` block seems to be required for every view). This does not change anything on consumer side.

### Problems

When using specific characters and then an emoji a very small jump can be seen. It looks like this is related to `float` -> `int` convertions, but I think it is tolerable as you have to look really closely to notice it. 