### PR TITLE
Avoid scrolling the emoji grid after opening the variant popup

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
@@ -56,6 +56,7 @@ final class EmojiVariantPopup {
     );
 
     popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
+    rootImageView.getParent().requestDisallowInterceptTouchEvent(true);
     Utils.fixPopupLocation(popupWindow, desiredLocation);
   }
 


### PR DESCRIPTION
This **finally** fixes the grid being scrollable after opening the variant popup. It does not focus the popup and lets you scroll through the variants though. Would partially fix #99.

### Code changes

- Very simple this time: After showing the popup we disallow touch interceptions by the `ImageView`'s parent.