### PR TITLE
Let Emoji provide a drawable in addition to the resource id. 

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
@@ -118,7 +118,7 @@ import static android.support.annotation.RestrictTo.Scope.LIBRARY;
       } : null);
 
       imageLoadingTask = new ImageLoadingTask(this);
-      imageLoadingTask.execute(emoji.getResource());
+      imageLoadingTask.execute(emoji);
     }
   }
 
@@ -133,7 +133,7 @@ import static android.support.annotation.RestrictTo.Scope.LIBRARY;
     if (!emoji.equals(currentEmoji)) {
       currentEmoji = emoji;
 
-      setImageResource(emoji.getResource());
+      setImageDrawable(emoji.getDrawable(this.getContext()));
     }
   }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -131,7 +131,7 @@ public final class EmojiManager {
       final EmojiRange location = findAllEmojis.get(i);
 
       if (!existingSpanPositions.contains(location.start)) {
-        text.setSpan(new EmojiSpan(context, location.emoji.getResource(), emojiSize),
+        text.setSpan(new EmojiSpan(context, location.emoji, emojiSize),
             location.start, location.end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
     }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -5,12 +5,13 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.text.style.ImageSpan;
+import com.vanniktech.emoji.emoji.Emoji;
 
 final class EmojiSpan extends ImageSpan {
   private final float size;
 
-  EmojiSpan(final Context context, final int drawableRes, final float size) {
-    super(context, drawableRes);
+  EmojiSpan(final Context context, final Emoji emoji, final float size) {
+    super(emoji.getDrawable(context));
 
     this.size = size;
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -11,7 +11,7 @@ final class EmojiSpan extends DynamicDrawableSpan {
   private final float size;
   private final Context context;
   private final Emoji emoji;
-  private Drawable mDrawable;
+  private Drawable deferredDrawable;
 
   EmojiSpan(final Context context, final Emoji emoji, final float size) {
     this.context = context;
@@ -20,11 +20,11 @@ final class EmojiSpan extends DynamicDrawableSpan {
   }
 
   @Override public Drawable getDrawable() {
-    if (mDrawable == null) {
-      mDrawable = emoji.getDrawable(context);
-      mDrawable.setBounds(0, 0, (int) size, (int) size);
+    if (deferredDrawable == null) {
+      deferredDrawable = emoji.getDrawable(context);
+      deferredDrawable.setBounds(0, 0, (int) size, (int) size);
     }
-    return mDrawable;
+    return defferedDrawable;
   }
 
   @Override public int getSize(final Paint paint, final CharSequence text, final int start,

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -4,24 +4,27 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
-import android.text.style.ImageSpan;
+import android.text.style.DynamicDrawableSpan;
 import com.vanniktech.emoji.emoji.Emoji;
 
-final class EmojiSpan extends ImageSpan {
+final class EmojiSpan extends DynamicDrawableSpan {
   private final float size;
+  private final Context context;
+  private final Emoji emoji;
+  private Drawable mDrawable;
 
   EmojiSpan(final Context context, final Emoji emoji, final float size) {
-    super(emoji.getDrawable(context));
-
+    this.context = context;
+    this.emoji = emoji;
     this.size = size;
   }
 
   @Override public Drawable getDrawable() {
-    final Drawable result = super.getDrawable();
-
-    result.setBounds(0, 0, (int) size, (int) size);
-
-    return result;
+    if (mDrawable == null) {
+      mDrawable = emoji.getDrawable(context);
+      mDrawable.setBounds(0, 0, (int) size, (int) size);
+    }
+    return mDrawable;
   }
 
   @Override public int getSize(final Paint paint, final CharSequence text, final int start,

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -24,7 +24,7 @@ final class EmojiSpan extends DynamicDrawableSpan {
       deferredDrawable = emoji.getDrawable(context);
       deferredDrawable.setBounds(0, 0, (int) size, (int) size);
     }
-    return defferedDrawable;
+    return deferredDrawable;
   }
 
   @Override public int getSize(final Paint paint, final CharSequence text, final int start,

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiVariantPopup.java
@@ -86,7 +86,7 @@ final class EmojiVariantPopup {
       // Use the same size for Emojis as in the picker.
       layoutParams.width = width;
       layoutParams.setMargins(margin, margin, margin, margin);
-      emojiImage.setImageResource(variant.getResource());
+      emojiImage.setImageDrawable(variant.getDrawable(context));
 
       emojiImage.setOnClickListener(new View.OnClickListener() {
         @Override public void onClick(final View view) {

--- a/emoji/src/main/java/com/vanniktech/emoji/ImageLoadingTask.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/ImageLoadingTask.java
@@ -6,9 +6,10 @@ import android.os.AsyncTask;
 import android.support.annotation.Nullable;
 import android.support.v7.content.res.AppCompatResources;
 import android.widget.ImageView;
+import com.vanniktech.emoji.emoji.Emoji;
 import java.lang.ref.WeakReference;
 
-final class ImageLoadingTask extends AsyncTask<Integer, Void, Drawable> {
+final class ImageLoadingTask extends AsyncTask<Emoji, Void, Drawable> {
   private final WeakReference<ImageView> imageViewReference;
   private final WeakReference<Context> contextReference;
 
@@ -17,11 +18,11 @@ final class ImageLoadingTask extends AsyncTask<Integer, Void, Drawable> {
     contextReference = new WeakReference<>(imageView.getContext());
   }
 
-  @Override protected Drawable doInBackground(final Integer... resource) {
+  @Override protected Drawable doInBackground(final Emoji... emoji) {
     final Context context = contextReference.get();
 
     if (context != null && !isCancelled()) {
-      return AppCompatResources.getDrawable(context, resource[0]);
+      return emoji[0].getDrawable(context);
     }
 
     return null;

--- a/emoji/src/main/java/com/vanniktech/emoji/ImageLoadingTask.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/ImageLoadingTask.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.annotation.Nullable;
-import android.support.v7.content.res.AppCompatResources;
 import android.widget.ImageView;
 import com.vanniktech.emoji.emoji.Emoji;
 import java.lang.ref.WeakReference;

--- a/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
@@ -54,7 +54,7 @@ public final class Emoji implements Serializable {
     return resource;
   }
 
-  @NonNull public Drawable getDrawable(Context context) {
+  @NonNull public Drawable getDrawable(final Context context) {
     return AppCompatResources.getDrawable(context, resource);
   }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
@@ -50,11 +50,11 @@ public final class Emoji implements Serializable {
    * @deprecated Please migrate to getDrawable(). May return -1 in the future for providers that don't use
    * resources.
    */
-  @DrawableRes public int getResource() {
+  @Deprecated @DrawableRes public int getResource() {
     return resource;
   }
 
-  public Drawable getDrawable(Context context) {
+  @NonNull public Drawable getDrawable(Context context) {
     return AppCompatResources.getDrawable(context, resource);
   }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
@@ -1,8 +1,11 @@
 package com.vanniktech.emoji.emoji;
 
+import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v7.content.res.AppCompatResources;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,8 +46,16 @@ public final class Emoji implements Serializable {
     return unicode;
   }
 
+  /**
+   * @deprecated Please migrate to getDrawable(). May return -1 in the future for providers that don't use
+   * resources.
+   */
   @DrawableRes public int getResource() {
     return resource;
+  }
+
+  public Drawable getDrawable(Context context) {
+    return AppCompatResources.getDrawable(context, resource);
   }
 
   @NonNull public List<Emoji> getVariants() {


### PR DESCRIPTION
Switch other code to use getDrawable() instead of getResource.
Will allow providers to provide optimized drawables, e.g. via spriting or by using the google emoji support library, addressing issue #88 