### PR TITLE
Empty list memory optimization

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.content.res.AppCompatResources;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -35,8 +36,8 @@ public class Emoji implements Serializable {
   public Emoji(@NonNull final int[] codePoints, @DrawableRes final int resource, final Emoji... variants) {
     this.unicode = new String(codePoints, 0, codePoints.length);
     this.resource = resource;
-    this.variants = asList(variants);
-
+    // asList seems to always allocate a new object, even for empty lists.
+    this.variants = variants.length == 0 ? Collections.<Emoji>emptyList() : asList(variants);
     for (final Emoji variant : variants) {
       variant.base = this;
     }


### PR DESCRIPTION
Don't allocate a list object for empty arrays; use Collections.emptyList() instead.