### PR TITLE
Update Support Library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
     targetSdkVersion = 26
     buildToolsVersion = '26.0.1'
 
-    supportLibraryVersion = '26.0.2'
+    supportLibraryVersion = '26.1.0'
     leakCanaryVersion = '1.5.1'
 
     versionCode = VERSION_CODE


### PR DESCRIPTION
This will fix #207.

Update the Support Library being used to version [`26.1.0`](https://developer.android.com/topic/libraries/support-library/revisions.html#26-1-0) released earlier this month. 