### PR TITLE
Fix for emoji keyboard UI artifact (while fast scrolling)

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
@@ -74,7 +74,7 @@ import static android.support.annotation.RestrictTo.Scope.LIBRARY;
   @Override protected void onDraw(final Canvas canvas) {
     super.onDraw(canvas);
 
-    if (hasVariants) {
+    if (hasVariants && getDrawable() != null) {
       canvas.drawPath(variantIndicatorPath, variantIndicatorPaint);
     }
   }


### PR DESCRIPTION
This change fixed UI issue (#221) for fast scrolling (inside emoji keyboard)

 <img src="https://user-images.githubusercontent.com/6691617/33478074-200fddda-d699-11e7-8794-466acc7b608c.jpg" width="300">

## Code changes

We just checking if lazy drawable initialization for EmojiImageView already was completed.