### PR TITLE
Add missing verifyInstalled to the EmojiManager

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
@@ -47,7 +47,7 @@ import android.util.AttributeSet;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
     final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
-    EmojiManager.replaceWithImages(getContext(), spannableStringBuilder, emojiSize, defaultEmojiSize);
+    EmojiManager.getInstance().replaceWithImages(getContext(), spannableStringBuilder, emojiSize, defaultEmojiSize);
     super.setText(spannableStringBuilder, type);
   }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -46,7 +46,7 @@ import com.vanniktech.emoji.emoji.Emoji;
   @Override @CallSuper protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
     final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
-    EmojiManager.replaceWithImages(getContext(), getText(), emojiSize, defaultEmojiSize);
+    EmojiManager.getInstance().replaceWithImages(getContext(), getText(), emojiSize, defaultEmojiSize);
   }
 
   @CallSuper public void backspace() {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -146,11 +146,10 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     INSTANCE.emojiReplacer = null;
   }
 
-  public static void replaceWithImages(final Context context, final Spannable text, final float emojiSize, final float defaultEmojiSize) {
+  public void replaceWithImages(final Context context, final Spannable text, final float emojiSize, final float defaultEmojiSize) {
     verifyInstalled();
 
-    final EmojiManager emojiManager = EmojiManager.getInstance();
-    emojiManager.emojiReplacer.replaceWithImages(context, text, emojiSize, defaultEmojiSize, DEFAULT_EMOJI_REPLACER);
+    emojiReplacer.replaceWithImages(context, text, emojiSize, defaultEmojiSize, DEFAULT_EMOJI_REPLACER);
   }
 
   EmojiCategory[] getCategories() {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -147,6 +147,8 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
   }
 
   public static void replaceWithImages(final Context context, final Spannable text, final float emojiSize, final float defaultEmojiSize) {
+    verifyInstalled();
+
     final EmojiManager emojiManager = EmojiManager.getInstance();
     emojiManager.emojiReplacer.replaceWithImages(context, text, emojiSize, defaultEmojiSize, DEFAULT_EMOJI_REPLACER);
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
@@ -47,7 +47,7 @@ import android.util.AttributeSet;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
     final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
-    EmojiManager.replaceWithImages(getContext(), spannableStringBuilder, emojiSize, defaultEmojiSize);
+    EmojiManager.getInstance().replaceWithImages(getContext(), spannableStringBuilder, emojiSize, defaultEmojiSize);
     super.setText(spannableStringBuilder, type);
   }
 

--- a/emoji/src/test/java/com/vanniktech/emoji/EmojiManagerTest.java
+++ b/emoji/src/test/java/com/vanniktech/emoji/EmojiManagerTest.java
@@ -133,7 +133,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString(new String(new int[] { 0x1234 }, 0, 1));
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 44, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 44, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(1);
   }
@@ -143,7 +143,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString("test" + new String(new int[] { 0x1234 }, 0, 1) + "abc");
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(1);
   }
@@ -153,7 +153,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString(new String(new int[] { 0x1234 }, 0, 1) + new String(new int[] { 0x5678 }, 0, 1));
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(2);
   }
@@ -163,7 +163,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString("abc" + new String(new int[] { 0x1234 }, 0, 1) + "cba" + new String(new int[] { 0x5678 }, 0, 1) + "xyz");
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(2);
   }
@@ -173,7 +173,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString(new String(new int[] { 0x1234, 0x4321 }, 0, 1));
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 11, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 11, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(1);
   }
@@ -183,7 +183,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString(new String(new int[] { 0x1234, 0x4321, 0x9999 }, 0, 1));
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(1);
   }
@@ -193,7 +193,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString("");
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(0);
   }
@@ -203,7 +203,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
     final Spannable text = new SpannableString("abcdefg");
 
-    EmojiManager.replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
+    EmojiManager.getInstance().replaceWithImages(RuntimeEnvironment.application, text, 22, 22);
 
     assertThat(text.getSpans(0, text.length(), EmojiSpan.class)).hasSize(0);
   }


### PR DESCRIPTION
I just ran into a problem where this check could have avoided confusion, so I thought I quickly add it.

I also made `replaceWithImages` non-static like the other methods. It looks weird having the `EmojiManager` call `getInstance` on itself, that should be responsibility of the caller imo.