### PR TITLE
Add release method which releases the sheet but not the data structure

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -135,15 +135,19 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
   }
 
   public static void destroy() {
-    for (final Emoji emoji : INSTANCE.emojiMap.values()) {
-      emoji.destroy();
-    }
+    release();
 
     INSTANCE.emojiMap.clear();
     INSTANCE.categories = null;
     INSTANCE.emojiPattern = null;
     INSTANCE.emojiRepetitivePattern = null;
     INSTANCE.emojiReplacer = null;
+  }
+
+  public static void release() {
+    for (final Emoji emoji : INSTANCE.emojiMap.values()) {
+      emoji.destroy();
+    }
   }
 
   public void replaceWithImages(final Context context, final Spannable text, final float emojiSize, final float defaultEmojiSize) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -135,7 +135,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
   }
 
   /**
-   * Destroys the EmojiManager. This means that all internal data structures are releases as well as
+   * Destroys the EmojiManager. This means that all internal data structures are released as well as
    * all data associated with installed {@link Emoji}s. For the existing {@link EmojiProvider}s this
    * means the memory-heavy emoji sheet.
    *

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiManager.java
@@ -134,6 +134,13 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     INSTANCE.emojiRepetitivePattern = Pattern.compile('(' + regex + ")+");
   }
 
+  /**
+   * Destroys the EmojiManager. This means that all internal data structures are releases as well as
+   * all data associated with installed {@link Emoji}s. For the existing {@link EmojiProvider}s this
+   * means the memory-heavy emoji sheet.
+   *
+   * @see #destroy()
+   */
   public static void destroy() {
     release();
 
@@ -144,6 +151,15 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     INSTANCE.emojiReplacer = null;
   }
 
+  /**
+   * Releases all data associated with installed {@link Emoji}s. For the existing {@link EmojiProvider}s this
+   * means the memory-heavy emoji sheet.
+   *
+   * In contrast to {@link #destroy()}, this does <b>not</b> destroy the internal
+   * data structures and thus, you do not need to {@link #install(EmojiProvider)} again before using the EmojiManager.
+   *
+   * @see #destroy()
+   */
   public static void release() {
     for (final Emoji emoji : INSTANCE.emojiMap.values()) {
       emoji.destroy();


### PR DESCRIPTION
This is from a personal use case which I can imagine is also relevant for others.

In my application, I want to release the heavy sheet `Bitmap` after leaving the relevant `Activity` but keep the emoji datastructure in memory to still have good performance when opening the `Activity` again. When using the existing `destroy` method, I would have to `install` a provider each time the `Activity` is opened, which blocks the main thread and causes a visible stutter in my case. This new `release` method allows to release the `Bitmap` when leaving and still installing the `Provider` once in a central place.