### PR TITLE
Allow customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ All of the core API lays in, which is being pulled in automatically by the provi
 compile 'com.vanniktech:emoji:0.5.1'
 ```
 
-### Inserting Emojis
+### Custom EditText
+
+If you want to add the emoji support to your existing `EditText`, you only have to
+`implement` `EmojiEditTextInterface`. An example can be seen on the default `EditText`
+implementation: `EmojiEditText`.
+
+---
+
+## Inserting Emojis
 
 Declare your [`EmojiEditText`](emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java) in your layout xml file.
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ ext {
           assertJ           : 'org.assertj:assertj-core:3.8.0'
   ]
 
-  javaVersion = JavaVersion.VERSION_1_7
+  javaVersion = JavaVersion.VERSION_1_8
 }
 
 task wrapper(type: Wrapper) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -11,7 +11,13 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import com.vanniktech.emoji.emoji.Emoji;
 
-@SuppressWarnings("CPD-START") public class EmojiEditText extends AppCompatEditText {
+/**
+ * Reference implementation for an EditText with emoji support.
+ */
+@SuppressWarnings("CPD-START") public class EmojiEditText
+                                    extends AppCompatEditText
+                                 implements EmojiEditTextInterface {
+
   private float emojiSize;
 
   public EmojiEditText(final Context context) {
@@ -49,11 +55,22 @@ import com.vanniktech.emoji.emoji.Emoji;
     EmojiManager.getInstance().replaceWithImages(getContext(), getText(), emojiSize, defaultEmojiSize);
   }
 
+  /* ------------------------------------------------- */
+  /* ---- Methods implemented from the intgerface ---- */
+  /* ------------------------------------------------- */
+
+  @Override
+  public float getEmojiSize () {
+    return emojiSize;
+  }
+
+  @Override
   @CallSuper public void backspace() {
     final KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_DEL, 0, 0, 0, 0, KeyEvent.KEYCODE_ENDCALL);
     dispatchKeyEvent(event);
   }
 
+  @Override
   @CallSuper public void input(final Emoji emoji) {
     if (emoji != null) {
       final int start = getSelectionStart();
@@ -68,11 +85,13 @@ import com.vanniktech.emoji.emoji.Emoji;
   }
 
   /** sets the emoji size in pixels and automatically invalidates the text and renders it with the new size */
+  @Override
   public final void setEmojiSize(@Px final int pixels) {
     setEmojiSize(pixels, true);
   }
 
   /** sets the emoji size in pixels and automatically invalidates the text and renders it with the new size when {@code shouldInvalidate} is true */
+  @Override
   public final void setEmojiSize(@Px final int pixels, final boolean shouldInvalidate) {
     emojiSize = pixels;
 
@@ -82,11 +101,13 @@ import com.vanniktech.emoji.emoji.Emoji;
   }
 
   /** sets the emoji size in pixels with the provided resource and automatically invalidates the text and renders it with the new size */
+  @Override
   public final void setEmojiSizeRes(@DimenRes final int res) {
     setEmojiSizeRes(res, true);
   }
 
   /** sets the emoji size in pixels with the provided resource and invalidates the text and renders it with the new size when {@code shouldInvalidate} is true */
+  @Override
   public final void setEmojiSizeRes(@DimenRes final int res, final boolean shouldInvalidate) {
     setEmojiSize(getResources().getDimensionPixelSize(res), shouldInvalidate);
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditTextInterface.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditTextInterface.java
@@ -1,0 +1,29 @@
+package com.vanniktech.emoji;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Paint;
+import android.support.annotation.CallSuper;
+import android.support.annotation.DimenRes;
+import android.support.annotation.Px;
+import android.support.v7.widget.AppCompatEditText;
+import android.widget.EditText;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import com.vanniktech.emoji.emoji.Emoji;
+
+/**
+ * Interface used to allow custom EmojiEditText objects on another project.
+ */
+public interface EmojiEditTextInterface {
+  float emojiSize = 1;
+
+  @CallSuper public void backspace();
+
+  @CallSuper public void input(final Emoji emoji);
+
+  public void setEmojiSize(@Px final int pixels);
+  public void setEmojiSize(@Px final int pixels, final boolean shouldInvalidate);
+  public void setEmojiSizeRes(@DimenRes final int res);
+  public void setEmojiSizeRes(@DimenRes final int res, final boolean shouldInvalidate);
+}

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditTextInterface.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditTextInterface.java
@@ -16,12 +16,12 @@ import com.vanniktech.emoji.emoji.Emoji;
  * Interface used to allow custom EmojiEditText objects on another project.
  */
 public interface EmojiEditTextInterface {
-  float emojiSize = 1;
 
   @CallSuper public void backspace();
 
   @CallSuper public void input(final Emoji emoji);
 
+  public float getEmojiSize();
   public void setEmojiSize(@Px final int pixels);
   public void setEmojiSize(@Px final int pixels, final boolean shouldInvalidate);
   public void setEmojiSizeRes(@DimenRes final int res);


### PR DESCRIPTION
I was trying to add support for a built-in emoji keyboard on [the Android client](https://github.com/vector-im/riot-android) for Riot, and I found this library, so I started figuring out how to do it. However, [the view](https://github.com/vector-im/riot-android/blob/develop/vector/src/main/java/im/vector/view/VectorAutoCompleteTextView.java) responsible for the keyboard inside the chats extends  `AppCompatMultiAutoCompleteTextView`, so it can't inherit `EmojiEditText` to add support.

In this pull request the class `EmojiEditText` has been replaced by an interface, **`EmojiEditTextInterface`**. Now, any class that wants to act as the emoji edit text (like `EmojiEditText` itself) has to implement those methods, and can extend from any class that's needed. Al this is reflected on the changed **README.md**.

---

I'm new to Android development, so there may be some things that I did wrong, or something missing; in which case I'd appreciate some help to fix it.

Also, I didn't see any contribution guidelines. If anything about the code is wrong (like the formatting), please let me know.