### PR TITLE
Allow to override background, icon and divider colors

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -92,7 +92,7 @@ public final class EmojiPopup {
             @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
     this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
-    this.editInterface  = editInterface ;
+    this.editInterface = editInterface;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);
     this.variantEmoji = variant != null ? variant : new VariantEmojiManager(context);
     this.backgroundColor = backgroundColor;
@@ -157,7 +157,7 @@ public final class EmojiPopup {
       if (isKeyboardOpen) {
         // If the keyboard is visible, simply show the emoji popup.
         showAtBottom();
-      } else if (editInterface  instanceof View) {
+      } else if (editInterface instanceof View) {
         final View view = (View) editInterface;
 
         // Open the text keyboard first and immediately after that show the emoji popup.

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -30,10 +30,10 @@ public final class EmojiPopup {
   static final int MIN_KEYBOARD_HEIGHT = 100;
 
   final View rootView;
-  Activity context;
-  @ColorInt int backgroundColor;
-  @ColorInt int iconColor;
-  @ColorInt int dividerColor;
+  final Activity context;
+  @ColorInt final int backgroundColor;
+  @ColorInt final int iconColor;
+  @ColorInt final int dividerColor;
 
   @NonNull final RecentEmoji recentEmoji;
   @NonNull final VariantEmoji variantEmoji;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -34,12 +34,9 @@ public final class EmojiPopup {
   private Activity context;
   private int backgroundColor, iconColor, dividerColor;
 
-  @NonNull
-  final RecentEmoji recentEmoji;
-  @NonNull
-  final VariantEmoji variantEmoji;
-  @NonNull
-  final EmojiVariantPopup variantPopup;
+  @NonNull final RecentEmoji recentEmoji;
+  @NonNull final VariantEmoji variantEmoji;
+  @NonNull final EmojiVariantPopup variantPopup;
 
   final PopupWindow popupWindow;
   final EmojiEditTextInterface editInterface;
@@ -47,19 +44,13 @@ public final class EmojiPopup {
   boolean isPendingOpen;
   boolean isKeyboardOpen;
 
-  @Nullable
-  OnEmojiPopupShownListener onEmojiPopupShownListener;
-  @Nullable
-  OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
-  @Nullable
-  OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
+  @Nullable OnEmojiPopupShownListener onEmojiPopupShownListener;
+  @Nullable OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
+  @Nullable OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
 
-  @Nullable
-  OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
-  @Nullable
-  OnEmojiClickListener onEmojiClickListener;
-  @Nullable
-  OnEmojiPopupDismissListener onEmojiPopupDismissListener;
+  @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+  @Nullable OnEmojiClickListener onEmojiClickListener;
+  @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
 
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
     @Override
@@ -222,30 +213,18 @@ public final class EmojiPopup {
   }
 
   public static final class Builder {
-    @NonNull
-    private final View rootView;
-    @Nullable
-    private int backgroundColor;
-    @Nullable
-    private int iconColor;
-    @Nullable
-    private int dividerColor;
-    @Nullable
-    private OnEmojiPopupShownListener onEmojiPopupShownListener;
-    @Nullable
-    private OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
-    @Nullable
-    private OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
-    @Nullable
-    private OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
-    @Nullable
-    private OnEmojiClickListener onEmojiClickListener;
-    @Nullable
-    private OnEmojiPopupDismissListener onEmojiPopupDismissListener;
-    @Nullable
-    private RecentEmoji recentEmoji;
-    @Nullable
-    private VariantEmoji variantEmoji;
+    @NonNull private final View rootView;
+    @Nullable private int backgroundColor;
+    @Nullable private int iconColor;
+    @Nullable private int dividerColor;
+    @Nullable private OnEmojiPopupShownListener onEmojiPopupShownListener;
+    @Nullable private OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
+    @Nullable private OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
+    @Nullable private OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+    @Nullable private OnEmojiClickListener onEmojiClickListener;
+    @Nullable private OnEmojiPopupDismissListener onEmojiPopupDismissListener;
+    @Nullable private RecentEmoji recentEmoji;
+    @Nullable private VariantEmoji variantEmoji;
 
     private Builder(final View rootView) {
       this.rootView = checkNotNull(rootView, "The root View can't be null");
@@ -256,43 +235,36 @@ public final class EmojiPopup {
      *                 of the keyboard.
      * @return builder For building the {@link EmojiPopup}.
      */
-    @CheckResult
-    public static Builder fromRootView(final View rootView) {
+    @CheckResult public static Builder fromRootView(final View rootView) {
       return new Builder(rootView);
     }
 
-    @CheckResult
-    public Builder setOnSoftKeyboardCloseListener(@Nullable final OnSoftKeyboardCloseListener listener) {
+    @CheckResult public Builder setOnSoftKeyboardCloseListener(@Nullable final OnSoftKeyboardCloseListener listener) {
       onSoftKeyboardCloseListener = listener;
       return this;
     }
 
-    @CheckResult
-    public Builder setOnEmojiClickListener(@Nullable final OnEmojiClickListener listener) {
+    @CheckResult public Builder setOnEmojiClickListener(@Nullable final OnEmojiClickListener listener) {
       onEmojiClickListener = listener;
       return this;
     }
 
-    @CheckResult
-    public Builder setOnSoftKeyboardOpenListener(@Nullable final OnSoftKeyboardOpenListener listener) {
+    @CheckResult public Builder setOnSoftKeyboardOpenListener(@Nullable final OnSoftKeyboardOpenListener listener) {
       onSoftKeyboardOpenListener = listener;
       return this;
     }
 
-    @CheckResult
-    public Builder setOnEmojiPopupShownListener(@Nullable final OnEmojiPopupShownListener listener) {
+    @CheckResult public Builder setOnEmojiPopupShownListener(@Nullable final OnEmojiPopupShownListener listener) {
       onEmojiPopupShownListener = listener;
       return this;
     }
 
-    @CheckResult
-    public Builder setOnEmojiPopupDismissListener(@Nullable final OnEmojiPopupDismissListener listener) {
+    @CheckResult public Builder setOnEmojiPopupDismissListener(@Nullable final OnEmojiPopupDismissListener listener) {
       onEmojiPopupDismissListener = listener;
       return this;
     }
 
-    @CheckResult
-    public Builder setOnEmojiBackspaceClickListener(@Nullable final OnEmojiBackspaceClickListener listener) {
+    @CheckResult public Builder setOnEmojiBackspaceClickListener(@Nullable final OnEmojiBackspaceClickListener listener) {
       onEmojiBackspaceClickListener = listener;
       return this;
     }
@@ -303,8 +275,7 @@ public final class EmojiPopup {
      *
      * @since 0.2.0
      */
-    @CheckResult
-    public Builder setRecentEmoji(@Nullable final RecentEmoji recent) {
+    @CheckResult public Builder setRecentEmoji(@Nullable final RecentEmoji recent) {
       recentEmoji = recent;
       return this;
     }
@@ -315,33 +286,28 @@ public final class EmojiPopup {
      *
      * @since 0.5.0
      */
-    @CheckResult
-    public Builder setVariantEmoji(@Nullable final VariantEmoji variant) {
+    @CheckResult public Builder setVariantEmoji(@Nullable final VariantEmoji variant) {
       variantEmoji = variant;
       return this;
     }
 
-    @CheckResult
-    public Builder setBackgroundColor(final int backgroundColor) {
+    @CheckResult public Builder setBackgroundColor(final int backgroundColor) {
       this.backgroundColor = backgroundColor;
 
       return this;
     }
 
-    @CheckResult
-    public Builder setIconColor(final int iconColor) {
+    @CheckResult public Builder setIconColor(final int iconColor) {
       this.iconColor = iconColor;
       return this;
     }
 
-    @CheckResult
-    public Builder setDividerColor(final int dividerColor) {
+    @CheckResult public Builder setDividerColor(final int dividerColor) {
       this.dividerColor = dividerColor;
       return this;
     }
 
-    @CheckResult
-    public EmojiPopup build(@NonNull final EmojiEditTextInterface editInterface) {
+    @CheckResult public EmojiPopup build(@NonNull final EmojiEditTextInterface editInterface) {
       EmojiManager.getInstance().verifyInstalled();
       checkNotNull(editInterface, "EmojiEditText can't be null");
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -3,7 +3,6 @@ package com.vanniktech.emoji;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
@@ -31,10 +30,10 @@ public final class EmojiPopup {
   static final int MIN_KEYBOARD_HEIGHT = 100;
 
   final View rootView;
-  private Activity context;
-  private int backgroundColor;
-  private int iconColor;
-  private int dividerColor;
+  Activity context;
+  @ColorInt int backgroundColor;
+  @ColorInt int iconColor;
+  @ColorInt int dividerColor;
 
   @NonNull final RecentEmoji recentEmoji;
   @NonNull final VariantEmoji variantEmoji;
@@ -89,7 +88,8 @@ public final class EmojiPopup {
   };
 
   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
-            @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
+            @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant,
+            @ColorInt final int backgroundColor, @ColorInt final int iconColor, @ColorInt final int dividerColor) {
     this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
     this.editInterface = editInterface;
@@ -211,9 +211,9 @@ public final class EmojiPopup {
 
   public static final class Builder {
     @NonNull private final View rootView;
-    @Nullable private int backgroundColor;
-    @Nullable private int iconColor;
-    @Nullable private int dividerColor;
+    @ColorInt private int backgroundColor;
+    @ColorInt private int iconColor;
+    @ColorInt private int dividerColor;
     @Nullable private OnEmojiPopupShownListener onEmojiPopupShownListener;
     @Nullable private OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
     @Nullable private OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
@@ -288,24 +288,24 @@ public final class EmojiPopup {
       return this;
     }
 
-    @CheckResult public Builder setBackgroundColor(@ColorInt int backgroundColor) {
-      this.backgroundColor = backgroundColor;
+    @CheckResult public Builder setBackgroundColor(@ColorInt final int color) {
+      backgroundColor = color;
       return this;
     }
 
-    @CheckResult public Builder setIconColor(@ColorInt int iconColor) {
-      this.iconColor = iconColor;
+    @CheckResult public Builder setIconColor(@ColorInt final int color) {
+      iconColor = color;
       return this;
     }
 
-    @CheckResult public Builder setDividerColor(@ColorInt int dividerColor) {
-      this.dividerColor = dividerColor;
+    @CheckResult public Builder setDividerColor(@ColorInt final int color) {
+      dividerColor = color;
       return this;
     }
 
     @CheckResult public EmojiPopup build(@NonNull final EmojiEditTextInterface editInterface) {
       EmojiManager.getInstance().verifyInstalled();
-      checkNotNull(editInterface, "EmojiEditText can't be null");
+      checkNotNull(editInterface, "EditText can't be null");
 
       final EmojiPopup emojiPopup = new EmojiPopup(rootView, editInterface, recentEmoji, variantEmoji, backgroundColor, iconColor, dividerColor);
       emojiPopup.onSoftKeyboardCloseListener = onSoftKeyboardCloseListener;
@@ -314,9 +314,6 @@ public final class EmojiPopup {
       emojiPopup.onEmojiPopupShownListener = onEmojiPopupShownListener;
       emojiPopup.onEmojiPopupDismissListener = onEmojiPopupDismissListener;
       emojiPopup.onEmojiBackspaceClickListener = onEmojiBackspaceClickListener;
-      emojiPopup.backgroundColor = backgroundColor;
-      emojiPopup.iconColor = iconColor;
-      emojiPopup.dividerColor = dividerColor;
       return emojiPopup;
     }
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -8,6 +8,7 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.support.annotation.CheckResult;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.Gravity;
@@ -32,7 +33,9 @@ public final class EmojiPopup {
 
   final View rootView;
   private Activity context;
-  private int backgroundColor, iconColor, dividerColor;
+  private int backgroundColor;
+  private int iconColor;
+  private int dividerColor;
 
   @NonNull final RecentEmoji recentEmoji;
   @NonNull final VariantEmoji variantEmoji;
@@ -87,7 +90,7 @@ public final class EmojiPopup {
     }
   };
 
-  public EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
+   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
                     @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
     this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
@@ -291,18 +294,17 @@ public final class EmojiPopup {
       return this;
     }
 
-    @CheckResult public Builder setBackgroundColor(final int backgroundColor) {
+    @CheckResult public Builder setBackgroundColor(@ColorInt int backgroundColor) {
       this.backgroundColor = backgroundColor;
-
       return this;
     }
 
-    @CheckResult public Builder setIconColor(final int iconColor) {
+    @CheckResult public Builder setIconColor(@ColorInt int iconColor) {
       this.iconColor = iconColor;
       return this;
     }
 
-    @CheckResult public Builder setDividerColor(final int dividerColor) {
+    @CheckResult public Builder setDividerColor(@ColorInt int dividerColor) {
       this.dividerColor = dividerColor;
       return this;
     }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -16,7 +16,6 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupWindow;
-
 import com.vanniktech.emoji.emoji.Emoji;
 import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiClickListener;
@@ -56,8 +55,7 @@ public final class EmojiPopup {
   @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
 
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
-    @Override
-    public void onGlobalLayout() {
+    @Override public void onGlobalLayout() {
       final Rect rect = Utils.windowVisibleDisplayFrame(context);
       final int heightDifference = Utils.screenHeight(context) - rect.bottom;
 
@@ -90,8 +88,8 @@ public final class EmojiPopup {
     }
   };
 
-   EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
-                    @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
+  EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
+            @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
     this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
     this.editInterface  = editInterface ;
@@ -104,15 +102,13 @@ public final class EmojiPopup {
     popupWindow = new PopupWindow(context);
 
     final OnEmojiLongClickListener longClickListener = new OnEmojiLongClickListener() {
-      @Override
-      public void onEmojiLongClick(@NonNull final EmojiImageView view, @NonNull final Emoji emoji) {
+      @Override public void onEmojiLongClick(@NonNull final EmojiImageView view, @NonNull final Emoji emoji) {
         variantPopup.show(view, emoji);
       }
     };
 
     final OnEmojiClickListener clickListener = new OnEmojiClickListener() {
-      @Override
-      public void onEmojiClick(@NonNull final EmojiImageView imageView, @NonNull final Emoji emoji) {
+      @Override public void onEmojiClick(@NonNull final EmojiImageView imageView, @NonNull final Emoji emoji) {
         editInterface.input(emoji);
 
         recentEmoji.addEmoji(emoji);
@@ -131,8 +127,7 @@ public final class EmojiPopup {
 
     final EmojiView emojiView = new EmojiView(context, clickListener, longClickListener, recentEmoji, variantEmoji, backgroundColor, iconColor, dividerColor);
     emojiView.setOnEmojiBackspaceClickListener(new OnEmojiBackspaceClickListener() {
-      @Override
-      public void onEmojiBackspaceClick(final View v) {
+      @Override public void onEmojiBackspaceClick(final View v) {
         editInterface.backspace();
 
         if (onEmojiBackspaceClickListener != null) {
@@ -145,8 +140,7 @@ public final class EmojiPopup {
     popupWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NOT_NEEDED);
     popupWindow.setBackgroundDrawable(new BitmapDrawable(context.getResources(), (Bitmap) null)); // To avoid borders and overdraw.
     popupWindow.setOnDismissListener(new PopupWindow.OnDismissListener() {
-      @Override
-      public void onDismiss() {
+      @Override public void onDismiss() {
         if (onEmojiPopupDismissListener != null) {
           onEmojiPopupDismissListener.onEmojiPopupDismiss();
         }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -31,9 +31,6 @@ public final class EmojiPopup {
 
   final View rootView;
   final Activity context;
-  @ColorInt final int backgroundColor;
-  @ColorInt final int iconColor;
-  @ColorInt final int dividerColor;
 
   @NonNull final RecentEmoji recentEmoji;
   @NonNull final VariantEmoji variantEmoji;
@@ -95,9 +92,6 @@ public final class EmojiPopup {
     this.editInterface = editInterface;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);
     this.variantEmoji = variant != null ? variant : new VariantEmojiManager(context);
-    this.backgroundColor = backgroundColor;
-    this.iconColor = iconColor;
-    this.dividerColor = dividerColor;
 
     popupWindow = new PopupWindow(context);
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -42,7 +42,7 @@ public final class EmojiPopup {
   final EmojiVariantPopup variantPopup;
 
   final PopupWindow popupWindow;
-  final EmojiEditTextInterface emojiEditText;
+  final EmojiEditTextInterface editInterface;
 
   boolean isPendingOpen;
   boolean isKeyboardOpen;
@@ -96,11 +96,11 @@ public final class EmojiPopup {
     }
   };
 
-  public EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface emojiEditText,
+  public EmojiPopup(@NonNull final View rootView, @NonNull final EmojiEditTextInterface editInterface,
                     @Nullable final RecentEmoji recent, @Nullable final VariantEmoji variant, int backgroundColor, int iconColor, int dividerColor) {
     this.context = Utils.asActivity(rootView.getContext());
     this.rootView = rootView.getRootView();
-    this.emojiEditText = emojiEditText;
+    this.editInterface  = editInterface ;
     this.recentEmoji = recent != null ? recent : new RecentEmojiManager(context);
     this.variantEmoji = variant != null ? variant : new VariantEmojiManager(context);
     this.backgroundColor = backgroundColor;
@@ -119,7 +119,7 @@ public final class EmojiPopup {
     final OnEmojiClickListener clickListener = new OnEmojiClickListener() {
       @Override
       public void onEmojiClick(@NonNull final EmojiImageView imageView, @NonNull final Emoji emoji) {
-        emojiEditText.input(emoji);
+        editInterface.input(emoji);
 
         recentEmoji.addEmoji(emoji);
         variantEmoji.addVariant(emoji);
@@ -139,7 +139,7 @@ public final class EmojiPopup {
     emojiView.setOnEmojiBackspaceClickListener(new OnEmojiBackspaceClickListener() {
       @Override
       public void onEmojiBackspaceClick(final View v) {
-        emojiEditText.backspace();
+        editInterface.backspace();
 
         if (onEmojiBackspaceClickListener != null) {
           onEmojiBackspaceClickListener.onEmojiBackspaceClick(v);
@@ -169,8 +169,8 @@ public final class EmojiPopup {
       if (isKeyboardOpen) {
         // If the keyboard is visible, simply show the emoji popup.
         showAtBottom();
-      } else if (emojiEditText instanceof View) {
-        final View view = (View) emojiEditText;
+      } else if (editInterface  instanceof View) {
+        final View view = (View) editInterface;
 
         // Open the text keyboard first and immediately after that show the emoji popup.
         view.setFocusableInTouchMode(true);
@@ -341,11 +341,11 @@ public final class EmojiPopup {
     }
 
     @CheckResult
-    public EmojiPopup build(@NonNull final EmojiEditTextInterface emojiEditText) {
+    public EmojiPopup build(@NonNull final EmojiEditTextInterface editInterface) {
       EmojiManager.getInstance().verifyInstalled();
-      checkNotNull(emojiEditText, "EmojiEditText can't be null");
+      checkNotNull(editInterface, "EmojiEditText can't be null");
 
-      final EmojiPopup emojiPopup = new EmojiPopup(rootView, emojiEditText, recentEmoji, variantEmoji, backgroundColor, iconColor, dividerColor);
+      final EmojiPopup emojiPopup = new EmojiPopup(rootView, editInterface, recentEmoji, variantEmoji, backgroundColor, iconColor, dividerColor);
       emojiPopup.onSoftKeyboardCloseListener = onSoftKeyboardCloseListener;
       emojiPopup.onEmojiClickListener = onEmojiClickListener;
       emojiPopup.onSoftKeyboardOpenListener = onSoftKeyboardOpenListener;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -37,10 +37,10 @@ import java.util.concurrent.TimeUnit;
 
   private int emojiTabLastSelectedIndex = -1;
 
-  public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
-            final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
-            @NonNull final VariantEmoji variantManager, @ColorInt final int backgroundColor,
-            @ColorInt final int iconColor, @ColorInt final int dividerColor) {
+  @SuppressWarnings("PMD.CyclomaticComplexity") public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
+        final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
+        @NonNull final VariantEmoji variantManager, @ColorInt final int backgroundColor,
+        @ColorInt final int iconColor, @ColorInt final int dividerColor) {
     super(context);
 
     View.inflate(context, R.layout.emoji_view, this);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -16,22 +16,19 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
-
 import com.vanniktech.emoji.emoji.EmojiCategory;
 import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiLongClickListener;
 import com.vanniktech.emoji.listeners.RepeatListener;
-
 import java.util.concurrent.TimeUnit;
 
-@SuppressLint("ViewConstructor")
-final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
+@SuppressLint("ViewConstructor") final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
   private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
   private static final int NORMAL_INTERVAL = 50;
 
   @ColorInt private final int themeAccentColor;
-  @ColorInt private int themeIconColor=0;
+  @ColorInt private final int themeIconColor;
 
   private final ImageButton[] emojiTabs;
   private final EmojiPagerAdapter emojiPagerAdapter;
@@ -40,25 +37,17 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
 
   private int emojiTabLastSelectedIndex = -1;
 
-  public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
+  EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
             final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
-            @NonNull final VariantEmoji variantManager, int backgroundColor, int iconColor, int dividerColor) {
+            @NonNull final VariantEmoji variantManager, @ColorInt final int backgroundColor,
+            @ColorInt final int iconColor, @ColorInt final int dividerColor) {
     super(context);
 
     View.inflate(context, R.layout.emoji_view, this);
 
     setOrientation(VERTICAL);
-    if (backgroundColor != 0)
-      setBackgroundColor(backgroundColor);
-    else
-      setBackgroundColor(ContextCompat.getColor(context, R.color.emoji_background));
-
-
-    if (iconColor != 0)
-      themeIconColor = iconColor;
-    else
-      themeIconColor=  ContextCompat.getColor(context, R.color.emoji_icons);
-
+    setBackgroundColor(backgroundColor != 0 ? backgroundColor : ContextCompat.getColor(context, R.color.emoji_background));
+    themeIconColor = iconColor != 0 ? iconColor : ContextCompat.getColor(context, R.color.emoji_icons);
 
     final TypedValue value = new TypedValue();
     context.getTheme().resolveAttribute(R.attr.colorAccent, value, true);
@@ -66,10 +55,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
 
     final ViewPager emojisPager = findViewById(R.id.emojis_pager);
     final View emojiDivider = findViewById(R.id.emoji_divider);
-    if (dividerColor != 0)
-      emojiDivider.setBackgroundColor(dividerColor);
-    else
-      emojiDivider.setBackgroundColor(getResources().getColor(R.color.emoji_divider));
+    emojiDivider.setBackgroundColor(dividerColor != 0 ? dividerColor : getResources().getColor(R.color.emoji_divider));
 
     final LinearLayout emojisTab = findViewById(R.id.emojis_tab);
     emojisPager.addOnPageChangeListener(this);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -30,20 +30,17 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
   private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
   private static final int NORMAL_INTERVAL = 50;
 
-  @ColorInt
-  private final int themeAccentColor;
-  @ColorInt
-  private int themeIconColor=0;
+  @ColorInt private final int themeAccentColor;
+  @ColorInt private int themeIconColor=0;
 
   private final ImageButton[] emojiTabs;
   private final EmojiPagerAdapter emojiPagerAdapter;
 
-  @Nullable
-  OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+  @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
 
   private int emojiTabLastSelectedIndex = -1;
 
-  EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
+  public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
             final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
             @NonNull final VariantEmoji variantManager, int backgroundColor, int iconColor, int dividerColor) {
     super(context);
@@ -102,8 +99,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     }
 
     emojiTabs[emojiTabs.length - 1].setOnTouchListener(new RepeatListener(INITIAL_INTERVAL, NORMAL_INTERVAL, new OnClickListener() {
-      @Override
-      public void onClick(final View view) {
+      @Override public void onClick(final View view) {
         if (onEmojiBackspaceClickListener != null) {
           onEmojiBackspaceClickListener.onEmojiBackspaceClick(view);
         }
@@ -126,8 +122,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     return button;
   }
 
-  @Override
-  public void onPageSelected(final int i) {
+  @Override public void onPageSelected(final int i) {
     if (emojiTabLastSelectedIndex != i) {
       if (i == 0) {
         emojiPagerAdapter.invalidateRecentEmojis();
@@ -145,13 +140,11 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
     }
   }
 
-  @Override
-  public void onPageScrolled(final int i, final float v, final int i2) {
+  @Override public void onPageScrolled(final int i, final float v, final int i2) {
     // No-op.
   }
 
-  @Override
-  public void onPageScrollStateChanged(final int i) {
+  @Override public void onPageScrollStateChanged(final int i) {
     // No-op.
   }
 
@@ -164,8 +157,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
       this.position = position;
     }
 
-    @Override
-    public void onClick(final View v) {
+    @Override public void onClick(final View v) {
       emojisPager.setCurrentItem(position);
     }
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -23,7 +23,7 @@ import com.vanniktech.emoji.listeners.OnEmojiLongClickListener;
 import com.vanniktech.emoji.listeners.RepeatListener;
 import java.util.concurrent.TimeUnit;
 
-@SuppressLint("ViewConstructor") final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
+@SuppressLint("ViewConstructor") public final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
   private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
   private static final int NORMAL_INTERVAL = 50;
 
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 
   private int emojiTabLastSelectedIndex = -1;
 
-  EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
+  public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
             final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
             @NonNull final VariantEmoji variantManager, @ColorInt final int backgroundColor,
             @ColorInt final int iconColor, @ColorInt final int dividerColor) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -16,43 +16,64 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
+
 import com.vanniktech.emoji.emoji.EmojiCategory;
 import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiLongClickListener;
 import com.vanniktech.emoji.listeners.RepeatListener;
+
 import java.util.concurrent.TimeUnit;
 
-@SuppressLint("ViewConstructor") public final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
+@SuppressLint("ViewConstructor")
+final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeListener {
   private static final long INITIAL_INTERVAL = TimeUnit.SECONDS.toMillis(1) / 2;
   private static final int NORMAL_INTERVAL = 50;
 
-  @ColorInt private final int themeAccentColor;
-  @ColorInt private final int themeIconColor;
+  @ColorInt
+  private final int themeAccentColor;
+  @ColorInt
+  private int themeIconColor=0;
 
   private final ImageButton[] emojiTabs;
   private final EmojiPagerAdapter emojiPagerAdapter;
 
-  @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
+  @Nullable
+  OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
 
   private int emojiTabLastSelectedIndex = -1;
 
-  public EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
+  EmojiView(final Context context, final OnEmojiClickListener onEmojiClickListener,
             final OnEmojiLongClickListener onEmojiLongClickListener, @NonNull final RecentEmoji recentEmoji,
-            @NonNull final VariantEmoji variantManager) {
+            @NonNull final VariantEmoji variantManager, int backgroundColor, int iconColor, int dividerColor) {
     super(context);
 
     View.inflate(context, R.layout.emoji_view, this);
 
     setOrientation(VERTICAL);
-    setBackgroundColor(ContextCompat.getColor(context, R.color.emoji_background));
+    if (backgroundColor != 0)
+      setBackgroundColor(backgroundColor);
+    else
+      setBackgroundColor(ContextCompat.getColor(context, R.color.emoji_background));
 
-    themeIconColor = ContextCompat.getColor(context, R.color.emoji_icons);
+
+    if (themeIconColor != 0)
+      themeIconColor = iconColor;
+    else
+      themeIconColor=  ContextCompat.getColor(context, R.color.emoji_icons);
+
+
     final TypedValue value = new TypedValue();
     context.getTheme().resolveAttribute(R.attr.colorAccent, value, true);
     themeAccentColor = value.data;
 
     final ViewPager emojisPager = findViewById(R.id.emojis_pager);
+    final View emojiDivider = findViewById(R.id.emoji_divider);
+    if (dividerColor != 0)
+      emojiDivider.setBackgroundColor(dividerColor);
+    else
+      emojiDivider.setBackgroundColor(getResources().getColor(R.color.emoji_divider));
+
     final LinearLayout emojisTab = findViewById(R.id.emojis_tab);
     emojisPager.addOnPageChangeListener(this);
 
@@ -81,7 +102,8 @@ import java.util.concurrent.TimeUnit;
     }
 
     emojiTabs[emojiTabs.length - 1].setOnTouchListener(new RepeatListener(INITIAL_INTERVAL, NORMAL_INTERVAL, new OnClickListener() {
-      @Override public void onClick(final View view) {
+      @Override
+      public void onClick(final View view) {
         if (onEmojiBackspaceClickListener != null) {
           onEmojiBackspaceClickListener.onEmojiBackspaceClick(view);
         }
@@ -104,7 +126,8 @@ import java.util.concurrent.TimeUnit;
     return button;
   }
 
-  @Override public void onPageSelected(final int i) {
+  @Override
+  public void onPageSelected(final int i) {
     if (emojiTabLastSelectedIndex != i) {
       if (i == 0) {
         emojiPagerAdapter.invalidateRecentEmojis();
@@ -122,11 +145,13 @@ import java.util.concurrent.TimeUnit;
     }
   }
 
-  @Override public void onPageScrolled(final int i, final float v, final int i2) {
+  @Override
+  public void onPageScrolled(final int i, final float v, final int i2) {
     // No-op.
   }
 
-  @Override public void onPageScrollStateChanged(final int i) {
+  @Override
+  public void onPageScrollStateChanged(final int i) {
     // No-op.
   }
 
@@ -139,7 +164,8 @@ import java.util.concurrent.TimeUnit;
       this.position = position;
     }
 
-    @Override public void onClick(final View v) {
+    @Override
+    public void onClick(final View v) {
       emojisPager.setCurrentItem(position);
     }
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -57,7 +57,7 @@ final class EmojiView extends LinearLayout implements ViewPager.OnPageChangeList
       setBackgroundColor(ContextCompat.getColor(context, R.color.emoji_background));
 
 
-    if (themeIconColor != 0)
+    if (iconColor != 0)
       themeIconColor = iconColor;
     else
       themeIconColor=  ContextCompat.getColor(context, R.color.emoji_icons);

--- a/emoji/src/main/res/layout/emoji_view.xml
+++ b/emoji/src/main/res/layout/emoji_view.xml
@@ -9,6 +9,7 @@
       />
 
   <View
+      android:id="@+id/emoji_divider"
       android:layout_width="match_parent"
       android:layout_height="1dp"
       android:background="@color/emoji_divider"


### PR DESCRIPTION
Hello, dear Niklas Baudy (Vacation)  first of all, I apologize for my English and thank u for your useful third- party. I use your Emoji third-party in my app but I needed to change background, divider and icon colors programmatically based on my themes. so I fork the Emoji and changed it on demand. now I can use three methods to change background, divider and icon colors in setUpEmojiPopup so we have 
this Three :
        .setBackgroundColor(Color.parseColor("#BDBDBD"))
        .setDividerColor(Color.parseColor("#42A5F5"))
        .setIconColor(Color.parseColor("#f0f0f0"))

Although if u don't use them. default values will call and there is no problem

With respect
Peyman Rashidian


