### PR TITLE
﻿Fix a crash when context instanceof ContextThemeWrapper

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -64,10 +64,10 @@ final class Utils {
 
     while (result instanceof ContextWrapper) {
       if (result instanceof Activity) {
-        return (Activity) context;
+        return (Activity) result;
       }
 
-      result = ((ContextWrapper) context).getBaseContext();
+      result = ((ContextWrapper) result).getBaseContext();
     }
 
     throw new IllegalArgumentException("The passed Context is not an Activity.");


### PR DESCRIPTION
Use in DialogFragment on Android 27 , 
the context is not instanceof Activity, lead to crash,
I fix it.