### PR TITLE
Upgrade Jimp to 0.5.0, remove manual promises

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -83,7 +83,7 @@ async function copyTargetImages(map, target, shouldOptimize) {
         await strip.blit(sheet, 0, 0, i * 66, 0, 66, height);
         const dest = `../emoji-${target.package}/src/main/res/drawable-nodpi/emoji_${target.package}_sheet_${i}.png`;
         if (shouldOptimize) {
-            const buffer = await new Promise((resolve, reject) => strip.getBuffer('image/png', (err, res) => err ? reject(err) : resolve(res)));
+            const buffer = await strip.getBufferAsync('image/png');
             const optimizedStrip = await imagemin.buffer(buffer, {
                 plugins: [
                     imageminPngquant(),
@@ -92,7 +92,7 @@ async function copyTargetImages(map, target, shouldOptimize) {
             });
             await fs.writeFile(dest, optimizedStrip);
         } else {
-            await new Promise((resolve, reject) => strip.write(dest, (err) => err ? reject(err) : resolve()));
+            await strip.writeAsync(dest);
         }
     }
 

--- a/generator/package.json
+++ b/generator/package.json
@@ -19,7 +19,7 @@
     "imagemin": "^5.3.1",
     "imagemin-pngquant": "^5.0.1",
     "imagemin-zopfli": "^5.1.0",
-    "jimp": "^0.2.28",
+    "jimp": "^0.5.0",
     "stable": "^0.1.6",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
The branch cleans up some manual promise handling from the generator by upgrading Jimp to the latest version.