### PR TITLE
Add attrs for color customization on theme level

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
@@ -7,7 +7,6 @@ import android.graphics.Path;
 import android.graphics.Point;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiImageView.java
@@ -38,7 +38,7 @@ public final class EmojiImageView extends AppCompatImageView {
   public EmojiImageView(final Context context, final AttributeSet attrs) {
     super(context, attrs);
 
-    variantIndicatorPaint.setColor(ContextCompat.getColor(context, R.color.emoji_divider));
+    variantIndicatorPaint.setColor(Utils.resolveColor(context, R.attr.emojiDivider, R.color.emoji_divider));
     variantIndicatorPaint.setStyle(Paint.Style.FILL);
     variantIndicatorPaint.setAntiAlias(true);
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -7,7 +7,6 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.content.res.AppCompatResources;
 import android.util.TypedValue;
@@ -46,8 +45,8 @@ import java.util.concurrent.TimeUnit;
     View.inflate(context, R.layout.emoji_view, this);
 
     setOrientation(VERTICAL);
-    setBackgroundColor(backgroundColor != 0 ? backgroundColor : ContextCompat.getColor(context, R.color.emoji_background));
-    themeIconColor = iconColor != 0 ? iconColor : ContextCompat.getColor(context, R.color.emoji_icons);
+    setBackgroundColor(backgroundColor != 0 ? backgroundColor : Utils.resolveColor(context, R.attr.emojiBackground, R.color.emoji_background));
+    themeIconColor = iconColor != 0 ? iconColor : Utils.resolveColor(context, R.attr.emojiIcons, R.color.emoji_icons);
 
     final TypedValue value = new TypedValue();
     context.getTheme().resolveAttribute(R.attr.colorAccent, value, true);
@@ -55,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 
     final ViewPager emojisPager = findViewById(R.id.emojis_pager);
     final View emojiDivider = findViewById(R.id.emoji_divider);
-    emojiDivider.setBackgroundColor(dividerColor != 0 ? dividerColor : getResources().getColor(R.color.emoji_divider));
+    emojiDivider.setBackgroundColor(dividerColor != 0 ? dividerColor : Utils.resolveColor(context, R.attr.emojiDivider, R.color.emoji_divider));
 
     final LinearLayout emojisTab = findViewById(R.id.emojis_tab);
     emojisPager.addOnPageChangeListener(this);

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -108,8 +108,7 @@ final class Utils {
     });
   }
 
-  @ColorInt
-  static int resolveColor(Context context, @AttrRes int resource, @ColorRes int fallback) {
+  @ColorInt static int resolveColor(final Context context, @AttrRes final int resource, @ColorRes final int fallback) {
     final TypedValue value = new TypedValue();
     context.getTheme().resolveAttribute(resource, value, true);
     final int resolvedColor;

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -6,8 +6,13 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.support.annotation.AttrRes;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.PopupWindow;
@@ -101,6 +106,25 @@ final class Utils {
         }
       }
     });
+  }
+
+  @ColorInt
+  static int resolveColor(Context context, @AttrRes int resource, @ColorRes int fallback) {
+    final TypedValue value = new TypedValue();
+    context.getTheme().resolveAttribute(resource, value, true);
+    final int resolvedColor;
+
+    if (value.resourceId != 0) {
+      resolvedColor = ContextCompat.getColor(context, value.resourceId);
+    } else {
+      resolvedColor = value.data;
+    }
+
+    if (resolvedColor != 0) {
+      return resolvedColor;
+    } else {
+      return ContextCompat.getColor(context, fallback);
+    }
   }
 
   private Utils() {

--- a/emoji/src/main/res/layout/emoji_skin_popup.xml
+++ b/emoji/src/main/res/layout/emoji_skin_popup.xml
@@ -7,7 +7,6 @@
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:cardBackgroundColor="@color/emoji_background"
         app:cardCornerRadius="1dp"
         app:cardElevation="2dp"
         app:cardUseCompatPadding="true">

--- a/emoji/src/main/res/layout/emoji_view.xml
+++ b/emoji/src/main/res/layout/emoji_view.xml
@@ -12,7 +12,6 @@
       android:id="@+id/emoji_divider"
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:background="@color/emoji_divider"
       />
 
   <android.support.v4.view.ViewPager

--- a/emoji/src/main/res/values/attrs.xml
+++ b/emoji/src/main/res/values/attrs.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <attr name="emojiSize" format="dimension"/>
+  <attr name="emojiBackground" format="color|reference"/>
+  <attr name="emojiIcons" format="color|reference"/>
+  <attr name="emojiDivider" format="color|reference"/>
 
   <declare-styleable name="EmojiButton">
     <attr name="emojiSize"/>


### PR DESCRIPTION
This allows to set these colors also on a theme level.
This change is backwards compatible, since the old behaviour is used, if an attribute is not defined in the theme.