### PR TITLE
Fix Layout issues in EmojiDialog for several edge cases.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
       tools:ignore="GoogleAppIndexingWarning">
     <activity
         android:name=".MainActivity"
-        android:windowSoftInputMode="stateHidden">
+        android:windowSoftInputMode="stateHidden|adjustResize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -39,7 +39,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:imeOptions="actionSend|flagNoExtractUi"
+        android:imeOptions="actionSend"
         android:inputType="textCapSentences|textMultiLine"
         android:maxLines="3"
         />

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -16,6 +16,7 @@ import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.PopupWindow;
+
 import com.vanniktech.emoji.emoji.Emoji;
 import com.vanniktech.emoji.listeners.OnEmojiBackspaceClickListener;
 import com.vanniktech.emoji.listeners.OnEmojiClickListener;
@@ -30,6 +31,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
 public final class EmojiPopup {
   static final int MIN_KEYBOARD_HEIGHT = 100;
+  static final float HEIGHT_DIFFERENCE_FACTOR = 1.4f;
 
   final View rootView;
   final Activity context;
@@ -52,23 +54,22 @@ public final class EmojiPopup {
   @Nullable OnEmojiClickListener onEmojiClickListener;
   @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
 
-  int correctionFactor = 0;
+  int correctionFactor;
 
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
     @Override public void onGlobalLayout() {
       final Rect rect = Utils.windowVisibleDisplayFrame(context);
       final int heightDifference = Utils.getScreenHeight(context) - rect.bottom;
 
-      boolean shouldOverrideRegularCondition =
-          Utils.shouldOverrideRegularCondition(context, editText);
-      if ((heightDifference > Utils.dpToPx(context, MIN_KEYBOARD_HEIGHT)
-          || shouldOverrideRegularCondition)) {
+      final boolean shouldOverrideRegularCondition = Utils.shouldOverrideRegularCondition(context, editText);
 
+      if (heightDifference > Utils.dpToPx(context, MIN_KEYBOARD_HEIGHT) || shouldOverrideRegularCondition) {
         correctionFactor = rect.top;
 
         int height = 0;
+
         if (shouldOverrideRegularCondition) {
-          height = (int) ((Utils.getScreenHeight(context) / 2) - (heightDifference * 1.4));
+          height = (int) ((Utils.getScreenHeight(context) / 2) - (heightDifference * HEIGHT_DIFFERENCE_FACTOR));
           popupWindow.setHeight(height);
         } else {
           height = heightDifference + correctionFactor;
@@ -99,8 +100,7 @@ public final class EmojiPopup {
           }
 
           dismiss();
-          Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(),
-              onGlobalLayoutListener);
+          Utils.removeOnGlobalLayoutListener(context.getWindow().getDecorView(), onGlobalLayoutListener);
         }
       }
     }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -29,7 +29,7 @@ import static com.vanniktech.emoji.Utils.backspace;
 import static com.vanniktech.emoji.Utils.checkNotNull;
 
 public final class EmojiPopup {
-  private static final int MIN_KEYBOARD_HEIGHT = 100;
+  static final int MIN_KEYBOARD_HEIGHT = 100;
 
   final View rootView;
   final Activity context;
@@ -52,7 +52,7 @@ public final class EmojiPopup {
   @Nullable OnEmojiClickListener onEmojiClickListener;
   @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
 
-  private int correctionFactor = 0;
+  int correctionFactor = 0;
 
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
     @Override public void onGlobalLayout() {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -64,22 +64,25 @@ public final class EmojiPopup {
       if ((heightDifference > Utils.dpToPx(context, MIN_KEYBOARD_HEIGHT)
           || shouldOverrideRegularCondition)) {
 
+        correctionFactor = rect.top;
+
+        int height = 0;
+        if (shouldOverrideRegularCondition) {
+          height = (int) ((Utils.getScreenHeight(context) / 2) - (heightDifference * 1.4));
+          popupWindow.setHeight(height);
+        } else {
+          height = heightDifference + correctionFactor;
+          popupWindow.setHeight(height);
+        }
+        popupWindow.setWidth(rect.right);
+
         if (!isKeyboardOpen && onSoftKeyboardOpenListener != null) {
-          onSoftKeyboardOpenListener.onKeyboardOpen(heightDifference);
+          onSoftKeyboardOpenListener.onKeyboardOpen(height);
         }
 
         isKeyboardOpen = true;
 
         if (isPendingOpen) {
-          if (shouldOverrideRegularCondition) {
-            popupWindow.setHeight(
-                (int) ((Utils.getScreenHeight(context) / 2) - (heightDifference * 1.5)));
-            correctionFactor = heightDifference;
-          } else {
-            popupWindow.setHeight(heightDifference - correctionFactor);
-          }
-          popupWindow.setWidth(rect.right);
-
           showAtBottom();
           isPendingOpen = false;
         }
@@ -204,7 +207,7 @@ public final class EmojiPopup {
   }
 
   void showAtBottom() {
-    final Point desiredLocation = new Point(0, Utils.getScreenHeight(context) - popupWindow.getHeight() - correctionFactor);
+    final Point desiredLocation = new Point(0, Utils.getScreenHeight(context) - popupWindow.getHeight() + correctionFactor);
 
     popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -57,7 +57,7 @@ public final class EmojiPopup {
   int correctionFactor;
 
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
-    @Override public void onGlobalLayout() {
+    @Override @SuppressWarnings("PMD.CyclomaticComplexity") public void onGlobalLayout() {
       final Rect rect = Utils.windowVisibleDisplayFrame(context);
       final int heightDifference = Utils.getScreenHeight(context) - rect.bottom;
 
@@ -69,7 +69,7 @@ public final class EmojiPopup {
         int height = 0;
 
         if (shouldOverrideRegularCondition) {
-          height = (int) ((Utils.getScreenHeight(context) / 2) - (heightDifference * HEIGHT_DIFFERENCE_FACTOR));
+          height = (int) (Utils.getScreenHeight(context) / 2.f - heightDifference * HEIGHT_DIFFERENCE_FACTOR);
           popupWindow.setHeight(height);
         } else {
           height = heightDifference + correctionFactor;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -69,7 +69,7 @@ public final class EmojiPopup {
         int height = 0;
 
         if (shouldOverrideRegularCondition) {
-          height = (int) (Utils.getScreenHeight(context) / 2.f - heightDifference * HEIGHT_DIFFERENCE_FACTOR);
+          height = (int) (Utils.getScreenHeight(context) / 2f - heightDifference * HEIGHT_DIFFERENCE_FACTOR);
           popupWindow.setHeight(height);
         } else {
           height = heightDifference + correctionFactor;

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -50,8 +50,7 @@ final class Utils {
     return (int) (dp * context.getResources().getDisplayMetrics().density);
   }
 
-  static boolean shouldOverrideRegularCondition(@NonNull final Activity context, EditText editText) {
-
+  static boolean shouldOverrideRegularCondition(@NonNull final Activity context, final EditText editText) {
     if ((editText.getImeOptions() & EditorInfo.IME_FLAG_NO_EXTRACT_UI) == 0) {
       return context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
     }

--- a/emoji/src/main/java/com/vanniktech/emoji/Utils.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/Utils.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.support.annotation.AttrRes;
@@ -16,6 +17,7 @@ import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.PopupWindow;
 
@@ -48,12 +50,17 @@ final class Utils {
     return (int) (dp * context.getResources().getDisplayMetrics().density);
   }
 
-  static int screenHeight(@NonNull final Activity context) {
-    final Point size = new Point();
+  static boolean shouldOverrideRegularCondition(@NonNull final Activity context, EditText editText) {
 
-    context.getWindowManager().getDefaultDisplay().getSize(size);
+    if ((editText.getImeOptions() & EditorInfo.IME_FLAG_NO_EXTRACT_UI) == 0) {
+      return context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+    }
 
-    return size.y;
+    return false;
+  }
+
+  static int getScreenHeight(@NonNull final Activity context) {
+    return dpToPx(context, context.getResources().getConfiguration().screenHeightDp);
   }
 
   @NonNull static Point locationOnScreen(@NonNull final View view) {


### PR DESCRIPTION
This PR fixes a few layout issues I've noticed, more importantly:

- it now properly aligns the emoji keyboard above soft navigation buttons at the bottom on some phones
- it now properly shows the emoji keyboard when using default edit text behaviour in horizontal orientation

This is still WIP as I want to clean it up and test, but feel free to test it yourself and comment - all feedback is more than welcome.

Signed-off-by: Mario Danic <mario@lovelyhq.com>