### PR TITLE
Fix memory leak in EmojiPopup

### DIFF
--- a/emoji-ios/src/main/java/com/vanniktech/emoji/ios/category/FlagsCategory.java
+++ b/emoji-ios/src/main/java/com/vanniktech/emoji/ios/category/FlagsCategory.java
@@ -290,4 +290,3 @@ import com.vanniktech.emoji.ios.IosEmoji;
     return R.string.emoji_ios_category_flags;
   }
 }
-

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -33,6 +33,7 @@ import com.vanniktech.emoji.listeners.OnSoftKeyboardCloseListener;
 import com.vanniktech.emoji.listeners.OnSoftKeyboardOpenListener;
 
 import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.O;
 import static com.vanniktech.emoji.Utils.backspace;
 import static com.vanniktech.emoji.Utils.checkNotNull;
@@ -70,6 +71,26 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
   final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
     @Override @SuppressWarnings("PMD.CyclomaticComplexity") public void onGlobalLayout() {
       updateKeyboardState();
+    }
+  };
+
+  final View.OnAttachStateChangeListener onAttachStateChangeListener = new View.OnAttachStateChangeListener() {
+    @Override public void onViewAttachedToWindow(final View v) {
+      // Unused.
+    }
+
+    @Override public void onViewDetachedFromWindow(final View v) {
+      dismiss();
+
+      popupWindow.setOnDismissListener(null);
+
+      if (SDK_INT >= JELLY_BEAN) {
+        rootView.getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
+      } else {
+        rootView.getViewTreeObserver().removeGlobalOnLayoutListener(onGlobalLayoutListener);
+      }
+
+      rootView.removeOnAttachStateChangeListener(this);
     }
   };
 
@@ -135,6 +156,7 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
       popupWindow.setAnimationStyle(animationStyle);
     }
 
+    rootView.addOnAttachStateChangeListener(onAttachStateChangeListener);
     rootView.getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
   }
 


### PR DESCRIPTION
This fixes #369.

I reproduced the issue with this code:

```java
public class MainActivity extends AppCompatActivity {

    private Handler handler = new Handler();

    @Override
    protected void onCreate(final Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);

        setContentView(R.layout.activity_main);

        replace();
    }

    private void replace() {
        handler.postDelayed(() -> {
            getSupportFragmentManager().beginTransaction()
                    .replace(R.id.root_test, new MainFragment())
                    .commitNow();

            replace();
        }, 10);
    }
}
```

The `MainFragment` (having the same code as the `MainActivity`) is replaced every 10 milliseconds.

I have done memory profiling with that and these are the results:

### Before

![](https://user-images.githubusercontent.com/8021265/61173597-bf515780-a595-11e9-8c2d-3a563d4578f9.png)

### After

![](https://user-images.githubusercontent.com/8021265/61173579-874a1480-a595-11e9-912a-7042506ef45a.png)

Before, the memory cosumption was rising without the gc being able to reclaim any, while now the usage remains constant.

To achieve this, we now register a `OnAttachStateChangeListener` on the `rootView` and remove the `OnGlobalLayoutListener` there. The popup is also dismissed to reduce problems when the user forgets to call the method manually.
