### PR TITLE
Automatically call start and stop when attaching/detaching EmojiPopup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,6 @@ emojiPopup.isShowing(); // Returns true when Popup is showing.
 The `rootView` is the rootView of your layout xml file which will be used for calculating the height of the keyboard.
 `emojiEditText` is the [`EmojiEditText`](emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java) that you declared in your layout xml file.
 
-The following code needs to be executed onStart() and after creating EmojiPopup instance:
-
-```java
-emojiPopup.start()
-```
-
-The following code needs to be executed in onStop():
-
-```java
-emojiPopup.stop()
-```
-
 **Note: Instantiate the `EmojiPopup` as early as possible in the lifecycle (e.g. in `onCreate` of your `Activity` or `onViewCreated` in your `Fragment`), otherwise the keyboard detection might not work as expected.**
 
 ### Displaying Emojis

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
@@ -94,7 +94,7 @@ import static android.view.View.VISIBLE;
   @Override public boolean onOptionsItemSelected(final MenuItem item) {
     switch (item.getItemId()) {
       case R.id.menuMainShowDialog:
-        emojiPopup.stop();
+        emojiPopup.dismiss();
         MainDialog.show(this);
         return true;
       case R.id.menuMainVariantIos:

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
@@ -127,22 +127,6 @@ import static android.view.View.VISIBLE;
     }
   }
 
-  @Override protected void onStart() {
-    if (emojiPopup != null) {
-      emojiPopup.start();
-    }
-
-    super.onStart();
-  }
-
-  @Override protected void onStop() {
-    if (emojiPopup != null) {
-      emojiPopup.stop();
-    }
-
-    super.onStop();
-  }
-
   private void setUpEmojiPopup() {
     emojiPopup = EmojiPopup.Builder.fromRootView(rootView)
         .setOnEmojiBackspaceClickListener(ignore -> Log.d(TAG, "Clicked on Backspace"))

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivityAutoCompeteTextView.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivityAutoCompeteTextView.java
@@ -77,7 +77,7 @@ import com.vanniktech.emoji.twitter.TwitterEmojiProvider;
   @Override public boolean onOptionsItemSelected(final MenuItem item) {
     switch (item.getItemId()) {
       case R.id.menuMainShowDialog:
-        emojiPopup.stop();
+        emojiPopup.dismiss();
         MainDialog.show(this);
         return true;
       case R.id.menuMainVariantIos:

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivityAutoCompeteTextView.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivityAutoCompeteTextView.java
@@ -118,22 +118,6 @@ import com.vanniktech.emoji.twitter.TwitterEmojiProvider;
     }
   }
 
-  @Override protected void onStart() {
-    if (emojiPopup != null) {
-      emojiPopup.start();
-    }
-
-    super.onStart();
-  }
-
-  @Override protected void onStop() {
-    if (emojiPopup != null) {
-      emojiPopup.stop();
-    }
-
-    super.onStop();
-  }
-
   private void setUpEmojiPopup() {
     emojiPopup = EmojiPopup.Builder.fromRootView(rootView)
         .setOnEmojiBackspaceClickListener(ignore -> Log.d(TAG, "Clicked on Backspace"))

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivityMultiAutoCompeteTextView.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivityMultiAutoCompeteTextView.java
@@ -77,7 +77,7 @@ import com.vanniktech.emoji.twitter.TwitterEmojiProvider;
   @Override public boolean onOptionsItemSelected(final MenuItem item) {
     switch (item.getItemId()) {
       case R.id.menuMainShowDialog:
-        emojiPopup.stop();
+        emojiPopup.dismiss();
         MainDialog.show(this);
         return true;
       case R.id.menuMainVariantIos:

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivityMultiAutoCompeteTextView.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivityMultiAutoCompeteTextView.java
@@ -118,22 +118,6 @@ import com.vanniktech.emoji.twitter.TwitterEmojiProvider;
     }
   }
 
-  @Override protected void onStart() {
-    if (emojiPopup != null) {
-      emojiPopup.start();
-    }
-
-    super.onStart();
-  }
-
-  @Override protected void onStop() {
-    if (emojiPopup != null) {
-      emojiPopup.stop();
-    }
-
-    super.onStop();
-  }
-
   private void setUpEmojiPopup() {
     emojiPopup = EmojiPopup.Builder.fromRootView(rootView)
         .setOnEmojiBackspaceClickListener(ignore -> Log.d(TAG, "Clicked on Backspace"))

--- a/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainDialog.java
@@ -40,22 +40,6 @@ import com.vanniktech.emoji.EmojiPopup;
     chatAdapter = new ChatAdapter();
   }
 
-  @Override public void onStart() {
-    if (emojiPopup != null) {
-      emojiPopup.start();
-    }
-
-    super.onStart();
-  }
-
-  @Override public void onStop() {
-    if (emojiPopup != null) {
-      emojiPopup.stop();
-    }
-
-    super.onStop();
-  }
-
   @Override @NonNull public Dialog onCreateDialog(final Bundle savedInstanceState) {
     return new AlertDialog.Builder(getContext())
             .setView(buildView())
@@ -104,7 +88,5 @@ import com.vanniktech.emoji.EmojiPopup;
         .setKeyboardAnimationStyle(R.style.emoji_fade_animation_style)
         .setPageTransformer(new PageTransformer())
         .build(editText);
-
-    emojiPopup.start();
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -165,7 +165,7 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
   }
 
   /** Call this method in your #onStart method. */
-  public void start() {
+  void start() {
     if (SDK_INT >= LOLLIPOP) {
       context.getWindow().getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
         int previousOffset;
@@ -199,7 +199,7 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
   }
 
   /** Call this method in your #onStop method. */
-  public void stop() {
+  void stop() {
     dismiss();
 
     if (SDK_INT >= LOLLIPOP) {

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -164,7 +164,6 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
     }
   }
 
-  /** Call this method in your #onStart method. */
   void start() {
     if (SDK_INT >= LOLLIPOP) {
       context.getWindow().getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
@@ -198,7 +197,6 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
     }
   }
 
-  /** Call this method in your #onStop method. */
   void stop() {
     dismiss();
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -73,11 +73,11 @@ public final class EmojiPopup implements EmojiResultReceiver.Receiver {
 
   final View.OnAttachStateChangeListener onAttachStateChangeListener = new View.OnAttachStateChangeListener() {
     @Override public void onViewAttachedToWindow(final View v) {
-      // Unused.
+      start();
     }
 
     @Override public void onViewDetachedFromWindow(final View v) {
-      dismiss();
+      stop();
 
       popupWindow.setOnDismissListener(null);
 


### PR DESCRIPTION
As proposed in https://github.com/vanniktech/Emoji/pull/389, this changes `EmojiPopup` to automatically call it's `start` and `stop` methods, making the library easier to use.

This is done by calling the methods as part of the `OnAttachStateChangeListener` lifecycle.

Tested on my real device (API 29) and it looks like it just works™️.