### PR TITLE
Delay opening of the popup to correctly align with window insets. Fixes #400

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -53,6 +53,9 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
   boolean isPendingOpen;
   boolean isKeyboardOpen;
 
+  private int globalKeyboardHeight;
+  private int delay;
+
   @Nullable OnEmojiPopupShownListener onEmojiPopupShownListener;
   @Nullable OnSoftKeyboardCloseListener onSoftKeyboardCloseListener;
   @Nullable OnSoftKeyboardOpenListener onSoftKeyboardOpenListener;
@@ -218,6 +221,13 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
       popupWindow.setHeight(keyboardHeight);
     }
 
+    if (globalKeyboardHeight != keyboardHeight) {
+      globalKeyboardHeight = keyboardHeight;
+      delay = 250;
+    } else {
+      delay = 0;
+    }
+
     final int properWidth = Utils.getProperWidth(context);
 
     if (popupWindow.getWidth() != properWidth) {
@@ -327,8 +337,12 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
   void showAtBottom() {
     isPendingOpen = false;
-    popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, 0,
-        Utils.getProperHeight(context) + popupWindowHeight);
+    editText.postDelayed(new Runnable() {
+      @Override public void run() {
+        popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, 0,
+            Utils.getProperHeight(context) + popupWindowHeight);
+      }
+    }, delay);
 
     if (onEmojiPopupShownListener != null) {
       onEmojiPopupShownListener.onEmojiPopupShown();

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -39,6 +39,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
 @SuppressWarnings("PMD.GodClass") public final class EmojiPopup implements EmojiResultReceiver.Receiver {
   static final int MIN_KEYBOARD_HEIGHT = 50;
+  static final int APPLY_WINDOW_INSETS_DURATION = 250;
 
   final View rootView;
   final Activity context;
@@ -223,7 +224,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
     if (globalKeyboardHeight != keyboardHeight) {
       globalKeyboardHeight = keyboardHeight;
-      delay = 250;
+      delay = APPLY_WINDOW_INSETS_DURATION;
     } else {
       delay = 0;
     }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -215,7 +215,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     }
   }
 
-  void updateKeyboardStateOpened(final int keyboardHeight) {
+  @SuppressWarnings("PMD.CyclomaticComplexity") void updateKeyboardStateOpened(final int keyboardHeight) {
     if (popupWindowHeight > 0 && popupWindow.getHeight() != popupWindowHeight) {
       popupWindow.setHeight(popupWindowHeight);
     } else if (popupWindowHeight == 0 && popupWindow.getHeight() != keyboardHeight) {


### PR DESCRIPTION
250ms is the amount of time the system needs to apply window insets that we set. Therefore, we need to delay opening of the popup by 250ms the first time we do it.

Signed-off-by: Mario Danic <mario@lovelyhq.com>