### PR TITLE
Add animation support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.15.0'
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.8.0'
 
-    classpath 'com.android.tools.build:gradle:3.5.1'
+    classpath 'com.android.tools.build:gradle:3.5.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.26.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
   }

--- a/emoji-google-compat/src/main/java/com/vanniktech/emoji/googlecompat/GoogleCompatEmoji.java
+++ b/emoji-google-compat/src/main/java/com/vanniktech/emoji/googlecompat/GoogleCompatEmoji.java
@@ -7,7 +7,7 @@ import com.vanniktech.emoji.emoji.Emoji;
 
 public final class GoogleCompatEmoji extends Emoji {
   public GoogleCompatEmoji(final int[] ints, final Emoji... emojis) {
-    super(ints, -1, false, emojis);
+    super(ints, -1, false, false, emojis);
   }
 
   public GoogleCompatEmoji(final int codePoint, final Emoji... emojis) {

--- a/emoji-google/src/main/java/com/vanniktech/emoji/google/GoogleEmoji.java
+++ b/emoji-google/src/main/java/com/vanniktech/emoji/google/GoogleEmoji.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
@@ -58,7 +59,7 @@ public class GoogleEmoji extends Emoji {
 
   public GoogleEmoji(@NonNull final int[] codePoints, final int x, final int y, final boolean isDuplicate,
                      final Emoji... variants) {
-    super(codePoints, -1, isDuplicate, variants);
+    super(codePoints, -1, isDuplicate, false, variants);
 
     this.x = x;
     this.y = y;

--- a/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmoji.java
+++ b/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmoji.java
@@ -102,8 +102,6 @@ public class IosEmoji extends Emoji {
     Log.d("TAG", "Still working in AnimatedDrawable");
 
     final Bitmap strip = loadStrip(context);
-    Log.d("TAG", "Still working after loading strip");
-    Log.d("Strip is: ", strip.toString());
     final Bitmap[] cut = loadAnimatedStrip(strip);
 
     AnimationDrawable animationDrawable = new AnimationDrawable();
@@ -112,8 +110,7 @@ public class IosEmoji extends Emoji {
     }
     animationDrawable.setOneShot(false);
 
-    System.out.println("Frames: " + animationDrawable.getNumberOfFrames());
-    System.out.println("Frames: " + animationDrawable.isRunning());
+    System.out.println("Frames in getAnimatedDrawable Method: " + animationDrawable.getNumberOfFrames());
 
     return animationDrawable;
   }
@@ -124,7 +121,7 @@ public class IosEmoji extends Emoji {
 
     for(line = 0; line * SPRITE_SIZE_INC_BORDER < bitmap.getHeight(); line++) {
       bitmapStripList.add(Bitmap.createBitmap(bitmap, 1, line * SPRITE_SIZE_INC_BORDER, SPRITE_SIZE, SPRITE_SIZE));
-      Log.d("TAG", bitmapStripList.get(bitmapStripList.size() - 1).toString());
+      Log.d("TAG", "Frame: " + line + " " +  bitmapStripList.get(bitmapStripList.size() - 1).toString());
     }
 
     Bitmap[] bitmapStripArray = new Bitmap[bitmapStripList.size()];

--- a/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmoji.java
+++ b/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmoji.java
@@ -4,15 +4,21 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
+
+import android.util.Log;
 import android.util.LruCache;
+import android.widget.ImageView;
 
 import com.vanniktech.emoji.emoji.CacheKey;
 import com.vanniktech.emoji.emoji.Emoji;
 
 import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.List;
 
 public class IosEmoji extends Emoji {
   private static final int CACHE_SIZE = 100;
@@ -58,22 +64,71 @@ public class IosEmoji extends Emoji {
 
   public IosEmoji(@NonNull final int[] codePoints, final int x, final int y, final boolean isDuplicate,
                      final Emoji... variants) {
-    super(codePoints, -1, isDuplicate, variants);
+    super(codePoints, -1, isDuplicate, false, variants);
+
+    this.x = x;
+    this.y = y;
+  }
+
+  public IosEmoji(@NonNull final int[] codePoints, final int x, final int y, final boolean isDuplicate,
+                  final boolean isAnimated, final Emoji... variants) {
+    super(codePoints, -1, isDuplicate, isAnimated, variants);
 
     this.x = x;
     this.y = y;
   }
 
   @Override @NonNull public Drawable getDrawable(final Context context) {
+
     final CacheKey key = new CacheKey(x, y);
     final Bitmap bitmap = BITMAP_CACHE.get(key);
-    if (bitmap != null) {
-      return new BitmapDrawable(context.getResources(), bitmap);
-    }
+
+    // TODO: Implement returning bitmapdrawable if existing based on one or several bitmaps existing
+    // if (bitmap != null) {
+    //  return new BitmapDrawable(context.getResources(), bitmap);
+    // }
+
+    return getDrawable(context, key);
+  }
+
+  private Drawable getDrawable(final Context context, CacheKey key) {
     final Bitmap strip = loadStrip(context);
     final Bitmap cut = Bitmap.createBitmap(strip, 1, y * SPRITE_SIZE_INC_BORDER + 1, SPRITE_SIZE, SPRITE_SIZE);
     BITMAP_CACHE.put(key, cut);
     return new BitmapDrawable(context.getResources(), cut);
+  }
+
+  @Override @NonNull public AnimationDrawable getAnimatedDrawable(final Context context) {
+    Log.d("TAG", "Still working in AnimatedDrawable");
+
+    final Bitmap strip = loadStrip(context);
+    Log.d("TAG", "Still working after loading strip");
+    Log.d("Strip is: ", strip.toString());
+    final Bitmap[] cut = loadAnimatedStrip(strip);
+
+    AnimationDrawable animationDrawable = new AnimationDrawable();
+    for (Bitmap bitmap : cut) {
+      animationDrawable.addFrame(new BitmapDrawable(context.getResources(), bitmap), 400);
+    }
+    animationDrawable.setOneShot(false);
+
+    System.out.println("Frames: " + animationDrawable.getNumberOfFrames());
+    System.out.println("Frames: " + animationDrawable.isRunning());
+
+    return animationDrawable;
+  }
+
+  private Bitmap[] loadAnimatedStrip(Bitmap bitmap) {
+    final List<Bitmap> bitmapStripList = new ArrayList<>();
+    int line;
+
+    for(line = 0; line * SPRITE_SIZE_INC_BORDER < bitmap.getHeight(); line++) {
+      bitmapStripList.add(Bitmap.createBitmap(bitmap, 1, line * SPRITE_SIZE_INC_BORDER, SPRITE_SIZE, SPRITE_SIZE));
+      Log.d("TAG", bitmapStripList.get(bitmapStripList.size() - 1).toString());
+    }
+
+    Bitmap[] bitmapStripArray = new Bitmap[bitmapStripList.size()];
+    return bitmapStripList.toArray(bitmapStripArray);
   }
 
   private Bitmap loadStrip(final Context context) {

--- a/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmojiProvider.java
+++ b/emoji-ios/src/main/java/com/vanniktech/emoji/ios/IosEmojiProvider.java
@@ -5,6 +5,7 @@ import com.vanniktech.emoji.EmojiProvider;
 import com.vanniktech.emoji.emoji.EmojiCategory;
 import com.vanniktech.emoji.ios.category.ActivitiesCategory;
 import com.vanniktech.emoji.ios.category.AnimalsAndNatureCategory;
+import com.vanniktech.emoji.ios.category.CustomAnimatedCategory;
 import com.vanniktech.emoji.ios.category.FlagsCategory;
 import com.vanniktech.emoji.ios.category.FoodAndDrinkCategory;
 import com.vanniktech.emoji.ios.category.ObjectsCategory;
@@ -22,7 +23,8 @@ public final class IosEmojiProvider implements EmojiProvider {
       new TravelAndPlacesCategory(),
       new ObjectsCategory(),
       new SymbolsCategory(),
-      new FlagsCategory()
+      new FlagsCategory(),
+      new CustomAnimatedCategory()
     };
   }
 }

--- a/emoji-ios/src/main/java/com/vanniktech/emoji/ios/category/CustomAnimatedCategory.java
+++ b/emoji-ios/src/main/java/com/vanniktech/emoji/ios/category/CustomAnimatedCategory.java
@@ -1,0 +1,25 @@
+package com.vanniktech.emoji.ios.category;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+
+import com.vanniktech.emoji.emoji.Emoji;
+import com.vanniktech.emoji.emoji.EmojiCategory;
+import com.vanniktech.emoji.ios.IosEmoji;
+import com.vanniktech.emoji.ios.R;
+
+@SuppressWarnings("PMD.MethodReturnsInternalArray") public final class CustomAnimatedCategory implements EmojiCategory {
+    private static final IosEmoji[] DATA = new IosEmoji[]{
+            new IosEmoji(new int[] { 0x1F43F, 0xFE0F, 0x1F43F, 0xFE0F }, 1, 0, false, true),
+    };
+
+    @Override @NonNull public Emoji[] getEmojis() { return DATA; }
+
+    @Override @DrawableRes
+    public int getIcon() {
+        return R.drawable.emoji_ios_category_flags;
+    }
+
+    @Override
+    public int getCategoryName() { return R.string.emoji_ios_category_flags; }
+}

--- a/emoji-twitter/src/main/java/com/vanniktech/emoji/twitter/TwitterEmoji.java
+++ b/emoji-twitter/src/main/java/com/vanniktech/emoji/twitter/TwitterEmoji.java
@@ -58,7 +58,7 @@ public class TwitterEmoji extends Emoji {
 
   public TwitterEmoji(@NonNull final int[] codePoints, final int x, final int y, final boolean isDuplicate,
                      final Emoji... variants) {
-    super(codePoints, -1, isDuplicate, variants);
+    super(codePoints, -1, isDuplicate, false, variants);
 
     this.x = x;
     this.y = y;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -3,8 +3,11 @@ package com.vanniktech.emoji;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.Drawable;
 import android.text.style.DynamicDrawableSpan;
+import android.util.Log;
+
 import com.vanniktech.emoji.emoji.Emoji;
 
 final class EmojiSpan extends DynamicDrawableSpan {
@@ -21,9 +24,16 @@ final class EmojiSpan extends DynamicDrawableSpan {
 
   @Override public Drawable getDrawable() {
     if (deferredDrawable == null) {
-      deferredDrawable = emoji.getDrawable(context);
+      if(emoji.isAnimated()) {
+        Log.d("TAG", "is animated");
+        deferredDrawable = emoji.getAnimatedDrawable(context);
+      } else {
+        Log.d("TAG", "is not animated");
+        deferredDrawable = emoji.getDrawable(context);
+      }
       deferredDrawable.setBounds(0, 0, (int) size, (int) size);
     }
+
     return deferredDrawable;
   }
 
@@ -46,7 +56,23 @@ final class EmojiSpan extends DynamicDrawableSpan {
   @Override public void draw(final Canvas canvas, final CharSequence text, final int start,
                              final int end, final float x, final int top, final int y,
                              final int bottom, final Paint paint) {
+
+    System.out.println("Starting to draw pic");
+
     final Drawable drawable = getDrawable();
+    if (drawable instanceof AnimationDrawable) {
+      drawAnimation(canvas, drawable, text, start, end, x, top, y, bottom, paint);
+    } else {
+      drawImage(canvas, drawable, text, start, end, x, top, y, bottom, paint);
+    }
+
+    System.out.println("Pic drawn show pic");
+  }
+
+  private void drawImage(final Canvas canvas, Drawable drawable, final CharSequence text, final int start,
+                         final int end, final float x, final int top, final int y,
+                         final int bottom, final Paint paint) {
+
     final Paint.FontMetrics paintFontMetrics = paint.getFontMetrics();
     final float fontHeight = paintFontMetrics.descent - paintFontMetrics.ascent;
     final float centerY = y + paintFontMetrics.descent - fontHeight / 2;
@@ -56,5 +82,41 @@ final class EmojiSpan extends DynamicDrawableSpan {
     canvas.translate(x, transitionY);
     drawable.draw(canvas);
     canvas.restore();
+  }
+
+  private void drawAnimation(final Canvas canvas, Drawable drawable, final CharSequence text, final int start,
+                             final int end, final float x, final int top, final int y,
+                             final int bottom, final Paint paint) {
+
+
+    // TODO: Create working AnimationDrawable implementation
+
+    AnimationDrawable animat = (AnimationDrawable) drawable;
+    Drawable drawableAnim = animat.getFrame(0);  // TODO: This does work
+    Drawable drawableAnim2 = animat.getFrame(0);  // TODO: This does not work, getFrame returns empty even though Frames saved is 52
+    drawImage(canvas, drawableAnim, text, start, end, x, top, y, bottom, paint);
+
+
+    // drawImage(canvas, drawable, text, start, end, x, top, y, bottom, paint);
+
+    /*
+    if(drawable instanceof AnimationDrawable) {
+      AnimationDrawable animation = (AnimationDrawable) drawable;
+      animation.getFrame(5).draw(canvas);
+      // animation.start();
+      System.out.println("Frames: " + animation.getNumberOfFrames());
+      System.out.println("Frames: " + animation.isOneShot());
+      System.out.println("Frames: " + animation.isRunning());
+
+      // AnimationDrawable animationDrawable = (AnimationDrawable) drawable;
+      // for(int i = 0; i < animationDrawable.getNumberOfFrames(); i++) {
+        //  drawImage(canvas, animationDrawable.getFrame(i), text, start, end, x, top, y, bottom, paint);
+
+      // }
+
+     */
+
+
+    Log.d("TAG", "Animation in EmojiSpan");
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiSpan.java
@@ -90,32 +90,15 @@ final class EmojiSpan extends DynamicDrawableSpan {
 
 
     // TODO: Create working AnimationDrawable implementation
-
-    AnimationDrawable animat = (AnimationDrawable) drawable;
-    Drawable drawableAnim = animat.getFrame(0);  // TODO: This does work
-    Drawable drawableAnim2 = animat.getFrame(0);  // TODO: This does not work, getFrame returns empty even though Frames saved is 52
+    
+    AnimationDrawable animation = (AnimationDrawable) drawable;
+    Drawable drawableAnim = animation.getFrame(0);  // TODO: This does work
+    Drawable drawableAnim2 = animation.getFrame(5);  // TODO: This does not work, getFrame returns null even though Frames saved is 52
     drawImage(canvas, drawableAnim, text, start, end, x, top, y, bottom, paint);
 
-
-    // drawImage(canvas, drawable, text, start, end, x, top, y, bottom, paint);
-
-    /*
-    if(drawable instanceof AnimationDrawable) {
-      AnimationDrawable animation = (AnimationDrawable) drawable;
-      animation.getFrame(5).draw(canvas);
-      // animation.start();
-      System.out.println("Frames: " + animation.getNumberOfFrames());
-      System.out.println("Frames: " + animation.isOneShot());
-      System.out.println("Frames: " + animation.isRunning());
-
-      // AnimationDrawable animationDrawable = (AnimationDrawable) drawable;
-      // for(int i = 0; i < animationDrawable.getNumberOfFrames(); i++) {
-        //  drawImage(canvas, animationDrawable.getFrame(i), text, start, end, x, top, y, bottom, paint);
-
-      // }
-
-     */
-
+    System.out.println("Frames in drawAnimation Method: " + animation.getNumberOfFrames()); // TODO: 52 Frames returned
+    // System.out.println("Frames: " + animation.isOneShot());
+    // System.out.println("Frames: " + animation.isRunning());
 
     Log.d("TAG", "Animation in EmojiSpan");
   }

--- a/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/emoji/Emoji.java
@@ -1,6 +1,7 @@
 package com.vanniktech.emoji.emoji;
 
 import android.content.Context;
+import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -20,12 +21,18 @@ public class Emoji implements Serializable {
   @NonNull private final String unicode;
   @DrawableRes private final int resource;
   private final boolean isDuplicate;
+  private final boolean isAnimated;
   @NonNull private final List<Emoji> variants;
   @Nullable private Emoji base;
 
   public Emoji(@NonNull final int[] codePoints, @DrawableRes final int resource,
                final boolean isDuplicate) {
-    this(codePoints, resource, isDuplicate, new Emoji[0]);
+    this(codePoints, resource, isDuplicate, false, new Emoji[0]);
+  }
+
+  public Emoji(@NonNull final int[] codePoints, @DrawableRes final int resource,
+               final boolean isDuplicate, final boolean isAnimated) {
+    this(codePoints, resource, isDuplicate, isAnimated, new Emoji[0]);
   }
 
   public Emoji(final int codePoint, @DrawableRes final int resource, final boolean isDuplicate) {
@@ -34,14 +41,15 @@ public class Emoji implements Serializable {
 
   public Emoji(final int codePoint, @DrawableRes final int resource, final boolean isDuplicate,
                final Emoji... variants) {
-    this(new int[]{codePoint}, resource, isDuplicate, variants);
+    this(new int[]{codePoint}, resource, isDuplicate,false,  variants);
   }
 
   public Emoji(@NonNull final int[] codePoints, @DrawableRes final int resource,
-               final boolean isDuplicate, final Emoji... variants) {
+               final boolean isDuplicate, final boolean isAnimated,  final Emoji... variants) {
     this.unicode = new String(codePoints, 0, codePoints.length);
     this.resource = resource;
     this.isDuplicate = isDuplicate;
+    this.isAnimated = isAnimated;
     this.variants = variants.length == 0 ? EMPTY_EMOJI_LIST : asList(variants);
     for (final Emoji variant : variants) {
       variant.base = this;
@@ -62,6 +70,10 @@ public class Emoji implements Serializable {
 
   @NonNull public Drawable getDrawable(final Context context) {
     return AppCompatResources.getDrawable(context, resource);
+  }
+
+  public AnimationDrawable getAnimatedDrawable(final Context context) {
+    return null;
   }
 
   public boolean isDuplicate() {
@@ -89,6 +101,8 @@ public class Emoji implements Serializable {
   public boolean hasVariants() {
     return !variants.isEmpty();
   }
+
+  public boolean isAnimated() { return isAnimated; }
 
   public void destroy() {
     // For inheritors to override.


### PR DESCRIPTION
I have added methods to allow for either returning a bitmap or an animated bitmap if isAnimated boolean is true. I created a new Category with the Flag symbol and used one of the sprite sheets already existing in order to do the testing (in the app itself the chosen category is the last in the line of category icons, you can see two flags at the end, it is the last flag). I was planning to use the same method that the current long sprite sheets use to display all images, just that instead of showing all these bitmaps separately, I combine all bitmaps into one animation to be played when selected. You can find this in the loadAnimatedStrip method. In order to create an animation I use the existing loadStrip method to create a sequence of bitmaps using AnimationDrawable object. The animation played for me when I tried starting the method in loadAnimatedStrip directly, however, it does not animate when I try to start the animation in drawAnimation method. This is where I get stuck and I cannot find why it does not work. I would appreciate if someone can have a short look and give me some hints on what might be going wrong! ;)