### PR TITLE
Fix render issue when isInEditMode()

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiButton.java
@@ -43,6 +43,11 @@ import android.util.AttributeSet;
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {
+    if (isInEditMode()) {
+      super.setText(rawText, type);
+      return;
+    }
+
     final CharSequence text = rawText == null ? "" : rawText;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -48,6 +48,8 @@ import com.vanniktech.emoji.emoji.Emoji;
   }
 
   @Override @CallSuper protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
+    if (isInEditMode()) return;
+
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
     final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;
     EmojiManager.getInstance().replaceWithImages(getContext(), getText(), emojiSize, defaultEmojiSize);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiEditText.java
@@ -48,7 +48,9 @@ import com.vanniktech.emoji.emoji.Emoji;
   }
 
   @Override @CallSuper protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
-    if (isInEditMode()) return;
+    if (isInEditMode()) {
+      return;
+    }
 
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();
     final float defaultEmojiSize = fontMetrics.descent - fontMetrics.ascent;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiTextView.java
@@ -43,6 +43,10 @@ import android.util.AttributeSet;
   }
 
   @Override @CallSuper public void setText(final CharSequence rawText, final BufferType type) {
+    if (isInEditMode()) {
+      super.setText(rawText, type);
+      return;
+    }
     final CharSequence text = rawText == null ? "" : rawText;
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text);
     final Paint.FontMetrics fontMetrics = getPaint().getFontMetrics();


### PR DESCRIPTION
EmojiTextView#setText() uses EmojiManager and get called in constructor

Therefore Android Studio's layout preview fails to render any subclass of EmojiTextView with "Please install an EmojiProvider" exception

http://prntscr.com/s2ofqp

`java.lang.IllegalStateException: Please install an EmojiProvider through the EmojiManager.install() method first.
	at com.vanniktech.emoji.EmojiManager.verifyInstalled(EmojiManager.java:213)
	at com.vanniktech.emoji.EmojiManager.replaceWithImages(EmojiManager.java:170)
	at com.vanniktech.emoji.EmojiTextView.setText(EmojiTextView.java:50)
	at android.widget.TextView.<init>(TextView.java:1616)
	at android.widget.TextView.<init>(TextView.java:968)
	at androidx.appcompat.widget.AppCompatTextView.<init>(AppCompatTextView.java:99)
	at androidx.appcompat.widget.AppCompatTextView.<init>(AppCompatTextView.java:95)
	at com.vanniktech.emoji.EmojiTextView.<init>(EmojiTextView.java:21)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.jetbrains.android.uipreview.ViewLoader.createNewInstance(ViewLoader.java:404)
	at org.jetbrains.android.uipreview.ViewLoader.loadClass(ViewLoader.java:187)
	at org.jetbrains.android.uipreview.ViewLoader.loadView(ViewLoader.java:145)
	at com.android.tools.idea.rendering.LayoutlibCallbackImpl.loadView(LayoutlibCallbackImpl.java:309)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:417)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:428)
	at android.view.BridgeInflater.createViewFromTag(BridgeInflater.java:332)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:1123)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:1097)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:1126)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:1097)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:1126)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:1097)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:682)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:501)
	at android.view.BridgeInflater.inflate(BridgeInflater.java:383)
	at android.view.View.inflate(View.java:25764)
	at kz.btsdigital.aitu.channel.posts.widget.ChannelHeaderView.<init>(ChannelHeaderView.kt:66)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.jetbrains.android.uipreview.ViewLoader.createNewInstance(ViewLoader.java:404)
	at org.jetbrains.android.uipreview.ViewLoader.loadClass(ViewLoader.java:187)
	at org.jetbrains.android.uipreview.ViewLoader.loadView(ViewLoader.java:145)
	at com.android.tools.idea.rendering.LayoutlibCallbackImpl.loadView(LayoutlibCallbackImpl.java:309)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:417)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:428)
	at android.view.BridgeInflater.createViewFromTag(BridgeInflater.java:332)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:1123)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:1097)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:682)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:501)
	at com.android.layoutlib.bridge.impl.RenderSessionImpl.inflate(RenderSessionImpl.java:328)
	at com.android.layoutlib.bridge.Bridge.createSession(Bridge.java:396)
	at com.android.tools.idea.layoutlib.LayoutLibrary.createSession(LayoutLibrary.java:209)
	at com.android.tools.idea.rendering.RenderTask.createRenderSession(RenderTask.java:608)
	at com.android.tools.idea.rendering.RenderTask.lambda$inflate$6(RenderTask.java:734)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
`