### PR TITLE
Multiple Emoji Popups in one Activity.

### DIFF
--- a/app/src/main/java/com/vanniktech/emoji/sample/CustomViewActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/CustomViewActivity.java
@@ -16,9 +16,15 @@ public class CustomViewActivity extends AppCompatActivity {
   @Override protected void onCreate(final Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    final CustomView customView = new CustomView(this, null);
-    setContentView(customView);
-    customView.setUpEmojiPopup();
+    final CustomView customView1 = new CustomView(this, null);
+    final CustomView customView2 = new CustomView(this, null);
+    final LinearLayout linearLayout = new LinearLayout(this);
+    linearLayout.setOrientation(LinearLayout.VERTICAL);
+    linearLayout.addView(customView1);
+    linearLayout.addView(customView2);
+    setContentView(linearLayout);
+    customView1.setUpEmojiPopup();
+    customView2.setUpEmojiPopup();
   }
 
   static class CustomView extends LinearLayout {


### PR DESCRIPTION
This one is funny.

Currently, EmojiPopup can more or less only be used for one EditText. Few ways to break things:

- 1st case
  - Click on the first edittext & insert emoji
  - Click on the second edittext & insert emoji
    - Expected: emoji in second edittext
    - Actual: it's in the first one
- 2nd case
  - Click on the first edittext & on the trigger button
    - Expected: emoji popup should be rendered correrctly
    - Actual: it's way off screen
    - Note: 2nd trigger button works though

UI screenshot for some context:

![android_screenshot_1591041532](https://user-images.githubusercontent.com/5759366/83448978-192f6a00-a453-11ea-8b56-ba9b684071e0.png)

@rubengees & @mario any ideas how to fix this? 

I feel like an EmojiPopup should be able to switch its EditText so we only create the popup once and can activate it on different EditTexts.
