### PR TITLE
Only construct RecentEmojiManager if one hasn’t already been set

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -364,13 +364,12 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     @Nullable OnEmojiBackspaceClickListener onEmojiBackspaceClickListener;
     @Nullable OnEmojiClickListener onEmojiClickListener;
     @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
-    @NonNull RecentEmoji recentEmoji;
+    @Nullable RecentEmoji recentEmoji;
     @NonNull VariantEmoji variantEmoji;
     int popupWindowHeight;
 
     private Builder(final View rootView) {
       this.rootView = checkNotNull(rootView, "The root View can't be null");
-      this.recentEmoji = new RecentEmojiManager(rootView.getContext());
       this.variantEmoji = new VariantEmojiManager(rootView.getContext());
     }
 
@@ -481,6 +480,10 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     @CheckResult public EmojiPopup build(@NonNull final EditText editText) {
       EmojiManager.getInstance().verifyInstalled();
       checkNotNull(editText, "EditText can't be null");
+
+      if(recentEmoji == null){
+        recentEmoji = new RecentEmojiManager(rootView.getContext());
+      }
 
       final EmojiPopup emojiPopup = new EmojiPopup(this, editText);
       emojiPopup.onSoftKeyboardCloseListener = onSoftKeyboardCloseListener;

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -481,7 +481,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
       EmojiManager.getInstance().verifyInstalled();
       checkNotNull(editText, "EditText can't be null");
 
-      if(recentEmoji == null){
+      if (recentEmoji == null) {
         recentEmoji = new RecentEmojiManager(rootView.getContext());
       }
 


### PR DESCRIPTION
This PR fixes issue #476 - Previously the `RecentEmojiManager` was being constructed when the builder was created.  This PR changes the builders `recentEmoji` field to @Nullable and performs the initialisation when build is called.  This way people can set their own emoji managers and manage the threading of any disk reads in whatever way suits them.