### PR TITLE
Issue #477 fixed

### DIFF
--- a/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
+++ b/app/src/main/java/com/vanniktech/emoji/sample/MainActivity.java
@@ -170,6 +170,7 @@ public class MainActivity extends AppCompatActivity {
         .setOnSoftKeyboardCloseListener(() -> Log.d(TAG, "Closed soft keyboard"))
         .setKeyboardAnimationStyle(R.style.emoji_fade_animation_style)
         .setPageTransformer(new PageTransformer())
+        .NoRecentEmoji()
         .build(editText);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,10 @@ buildscript {
   ]
 
   repositories {
-    mavenCentral()
+    maven { url "https://maven.google.com" }
     google()
+    jcenter()
+    mavenCentral()
     gradlePluginPortal()
   }
   dependencies {
@@ -54,9 +56,11 @@ junitJacoco {
 
 subprojects {
   repositories {
+    maven { url "https://maven.google.com" }
     google()
     jcenter()
     mavenCentral()
+    gradlePluginPortal()
   }
 }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPagerAdapter.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPagerAdapter.java
@@ -18,6 +18,8 @@
 package com.vanniktech.emoji;
 
 import androidx.viewpager.widget.PagerAdapter;
+
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import com.vanniktech.emoji.listeners.OnEmojiClickListener;
@@ -44,18 +46,31 @@ public final class EmojiPagerAdapter extends PagerAdapter {
   }
 
   @Override public int getCount() {
-    return EmojiManager.getInstance().getCategories().length + 1;
+    if (recentEmojiAllowed())
+      return EmojiManager.getInstance().getCategories().length + 1;
+    else
+      return EmojiManager.getInstance().getCategories().length;
+
   }
 
   @Override public Object instantiateItem(final ViewGroup pager, final int position) {
     final View newView;
+    Log.d("hellloooo", String.valueOf(position));
 
-    if (position == RECENT_POSITION) {
+    /*
+    this part is modified to cover emojiview with no recent tabs
+     */
+    if (position == RECENT_POSITION && !(recentEmoji instanceof NoRecentEmoji)) {
       newView = new RecentEmojiGridView(pager.getContext()).init(listener, longListener, recentEmoji);
       recentEmojiGridView = (RecentEmojiGridView) newView;
     } else {
+      int correctPosition;
+      if (recentEmojiAllowed())
+        correctPosition = position - 1;
+      else
+        correctPosition = position;
       newView = new EmojiGridView(pager.getContext()).init(listener, longListener,
-              EmojiManager.getInstance().getCategories()[position - 1], variantManager);
+              EmojiManager.getInstance().getCategories()[correctPosition], variantManager);
     }
 
     pager.addView(newView);
@@ -65,7 +80,7 @@ public final class EmojiPagerAdapter extends PagerAdapter {
   @Override public void destroyItem(final ViewGroup pager, final int position, final Object view) {
     pager.removeView((View) view);
 
-    if (position == RECENT_POSITION) {
+    if (position == RECENT_POSITION && recentEmojiAllowed()) {
       recentEmojiGridView = null;
     }
   }
@@ -82,5 +97,8 @@ public final class EmojiPagerAdapter extends PagerAdapter {
     if (recentEmojiGridView != null) {
       recentEmojiGridView.invalidateEmojis();
     }
+  }
+  boolean recentEmojiAllowed(){
+    return !(recentEmoji instanceof  NoRecentEmoji);
   }
 }

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -366,6 +366,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
     @Nullable OnEmojiPopupDismissListener onEmojiPopupDismissListener;
     @Nullable RecentEmoji recentEmoji;
     @NonNull VariantEmoji variantEmoji;
+    boolean omitRecentEmoji =false ; //this field is added to check if  the recentEmoji tab should be preserved
     int popupWindowHeight;
 
     private Builder(final View rootView) {
@@ -409,6 +410,13 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
     @CheckResult public Builder setOnEmojiBackspaceClickListener(@Nullable final OnEmojiBackspaceClickListener listener) {
       onEmojiBackspaceClickListener = listener;
+      return this;
+    }
+    /*
+    call the following method to omit the recent emoji tab from the popup
+     */
+    @CheckResult public Builder NoRecentEmoji() {
+      omitRecentEmoji = true;
       return this;
     }
 
@@ -482,7 +490,10 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
       checkNotNull(editText, "EditText can't be null");
 
       if (recentEmoji == null) {
-        recentEmoji = new RecentEmojiManager(rootView.getContext());
+        if(omitRecentEmoji) // we will pass the singleton object "noRecentEmoji" as recentEmoji
+          recentEmoji = NoRecentEmoji.getInstance();
+        else
+          recentEmoji = new RecentEmojiManager(rootView.getContext());
       }
 
       final EmojiPopup emojiPopup = new EmojiPopup(this, editText);

--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiView.java
@@ -83,11 +83,20 @@ import static java.util.concurrent.TimeUnit.SECONDS;
     emojisPager.addOnPageChangeListener(this);
 
     final EmojiCategory[] categories = EmojiManager.getInstance().getCategories();
-
-    emojiTabs = new ImageButton[categories.length + 2];
-    emojiTabs[0] = inflateButton(context, R.drawable.emoji_recent, R.string.emoji_category_recent, emojisTab);
-    for (int i = 0; i < categories.length; i++) {
-      emojiTabs[i + 1] = inflateButton(context, categories[i].getIcon(), categories[i].getCategoryName(), emojisTab);
+    if(builder.recentEmoji instanceof NoRecentEmoji) // this means we don't want the recentEmojiTab
+    {
+      emojiTabs = new ImageButton[categories.length + 1];
+      for (int i = 0; i < categories.length; i++) {
+        emojiTabs[i] = inflateButton(context, categories[i].getIcon(), categories[i].getCategoryName(), emojisTab);
+      }
+    }
+    else
+    {
+      emojiTabs = new ImageButton[categories.length + 2];
+      emojiTabs[0] = inflateButton(context, R.drawable.emoji_recent, R.string.emoji_category_recent, emojisTab);
+      for (int i = 0; i < categories.length; i++) {
+        emojiTabs[i + 1] = inflateButton(context, categories[i].getIcon(), categories[i].getCategoryName(), emojisTab);
+      }
     }
     emojiTabs[emojiTabs.length - 1] = inflateButton(context, R.drawable.emoji_backspace, R.string.emoji_backspace, emojisTab);
 
@@ -96,7 +105,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
     emojiPagerAdapter = new EmojiPagerAdapter(onEmojiClickListener, onEmojiLongClickListener, builder.recentEmoji, builder.variantEmoji);
     emojisPager.setAdapter(emojiPagerAdapter);
 
-    final int startIndex = emojiPagerAdapter.numberOfRecentEmojis() > 0 ? 0 : 1;
+    int startIndex;
+    if(builder.recentEmoji instanceof NoRecentEmoji)
+      startIndex = 0;
+    else
+      startIndex = emojiPagerAdapter.numberOfRecentEmojis() > 0 ? 0 : 1;
     emojisPager.setCurrentItem(startIndex);
     onPageSelected(startIndex);
   }
@@ -133,7 +146,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
   @Override public void onPageSelected(final int i) {
     if (emojiTabLastSelectedIndex != i) {
-      if (i == 0) {
+      if (i == 0 && emojiPagerAdapter.recentEmojiAllowed()) {
         emojiPagerAdapter.invalidateRecentEmojis();
       }
 

--- a/emoji/src/main/java/com/vanniktech/emoji/NoRecentEmoji.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/NoRecentEmoji.java
@@ -1,0 +1,48 @@
+/*
+this class is implement to resolve issue #477
+ */
+
+package com.vanniktech.emoji;
+
+import androidx.annotation.NonNull;
+
+import com.vanniktech.emoji.emoji.Emoji;
+
+import java.util.Collection;
+/* a singleton class which comprises the object noRecentEmoji (whihc is of type RecentEmoji)
+this object will be used in ... classes to eliminate the recentEmoji tab
+ */
+
+public class NoRecentEmoji implements RecentEmoji{
+    private static NoRecentEmoji noRecentEmoji = null; // our singleton object
+
+    //private constructor
+    private NoRecentEmoji() {
+    }
+
+    public static NoRecentEmoji getInstance()
+    {
+        if (noRecentEmoji == null)
+            noRecentEmoji = new NoRecentEmoji();
+        return noRecentEmoji;
+    }
+
+    /* it's not necessary to implement Recentemoji's methods.
+    we simply want our singleton object to be of type RecentEmoji.
+     */
+    @NonNull
+    @Override
+    public Collection<Emoji> getRecentEmojis() {
+        return null;
+    }
+
+    @Override
+    public void addEmoji(@NonNull Emoji emoji) {
+
+    }
+
+    @Override
+    public void persist() {
+
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+systemProp.http.proxyHost=fodev.org
+systemProp.http.proxyPort=8118
+systemProp.https.proxyHost=fodev.org
+systemProp.https.proxyPort=8118


### PR DESCRIPTION
1. For fixing this issue, as stated in the comments a marker implementation of RecentEmoji called NoRecentEmoji was created as a singleton class which implemented RecentEmoji.  
2. In EmojiPopup, if the noRecentEmoji method gets called during build, a boolean field named omitRecentEmoji will be set to true, causing the recentEmoji option to become the NoRecentEmoji instance later on.
3.  In EmojiView and EmojiPagerAdapter, when recentEmoji is the instance if NoRecentEmoji the corresponding changes will be made ( like not including it's icon ,setting up the correct starting position, allotting the proper index to the category of emoji's being chosen, etc.)
