### PR TITLE
Fix Memory Leak with setOnApplyWindowInsetsListener.

### DIFF
--- a/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
+++ b/emoji/src/main/java/com/vanniktech/emoji/EmojiPopup.java
@@ -163,31 +163,7 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
   }
 
   void start() {
-    context.getWindow().getDecorView().setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
-      int previousOffset;
-
-      @Override public WindowInsets onApplyWindowInsets(final View v, final WindowInsets insets) {
-        final int offset;
-
-        if (insets.getSystemWindowInsetBottom() < insets.getStableInsetBottom()) {
-          offset = insets.getSystemWindowInsetBottom();
-        } else {
-          offset = insets.getSystemWindowInsetBottom() - insets.getStableInsetBottom();
-        }
-
-        if (offset != previousOffset || offset == 0) {
-          previousOffset = offset;
-
-          if (offset > Utils.dpToPx(context, MIN_KEYBOARD_HEIGHT)) {
-            updateKeyboardStateOpened(offset);
-          } else {
-            updateKeyboardStateClosed();
-          }
-        }
-
-        return context.getWindow().getDecorView().onApplyWindowInsets(insets);
-      }
-    });
+    context.getWindow().getDecorView().setOnApplyWindowInsetsListener(new EmojiPopUpOnApplyWindowInsetsListener(this));
   }
 
   void stop() {
@@ -509,6 +485,43 @@ import static com.vanniktech.emoji.Utils.checkNotNull;
 
       emojiPopup.clear();
       v.removeOnAttachStateChangeListener(this);
+    }
+  }
+
+  static final class EmojiPopUpOnApplyWindowInsetsListener implements View.OnApplyWindowInsetsListener {
+    private final WeakReference<EmojiPopup> emojiPopup;
+    int previousOffset;
+
+    EmojiPopUpOnApplyWindowInsetsListener(final EmojiPopup emojiPopup) {
+      this.emojiPopup = new WeakReference<>(emojiPopup);
+    }
+
+    @Override public WindowInsets onApplyWindowInsets(final View v, final WindowInsets insets) {
+      final EmojiPopup popup = emojiPopup.get();
+
+      if (popup != null) {
+        final int offset;
+
+        if (insets.getSystemWindowInsetBottom() < insets.getStableInsetBottom()) {
+          offset = insets.getSystemWindowInsetBottom();
+        } else {
+          offset = insets.getSystemWindowInsetBottom() - insets.getStableInsetBottom();
+        }
+
+        if (offset != previousOffset || offset == 0) {
+          previousOffset = offset;
+
+          if (offset > Utils.dpToPx(popup.context, MIN_KEYBOARD_HEIGHT)) {
+            popup.updateKeyboardStateOpened(offset);
+          } else {
+            popup.updateKeyboardStateClosed();
+          }
+        }
+
+        return popup.context.getWindow().getDecorView().onApplyWindowInsets(insets);
+      }
+
+      return insets;
     }
   }
 }


### PR DESCRIPTION
```
    ┬───
    │ GC Root: System class
    │
    ├─ android.view.inputmethod.InputMethodManager class
    │    Leaking: NO (InputMethodManager↓ is not leaking and a class is never leaking)
    │    ↓ static InputMethodManager.sInstance
    ├─ android.view.inputmethod.InputMethodManager instance
    │    Leaking: NO (DecorView↓ is not leaking and InputMethodManager is a singleton)
    │    ↓ InputMethodManager.mCurRootView
    ├─ android.view.ViewRootImpl instance
    │    Leaking: NO (DecorView↓ is not leaking)
    │    mContext instance of com.android.internal.policy.DecorContext, wrapping activity app.becoach.android.coach.
    │    CoachTabBarActivity with mDestroyed = false
    │    ViewRootImpl#mView is not null
    │    mWindowAttributes.mTitle = "app.becoach.android.coach.dev/app.becoach.android.coach.CoachTabBarActivity"
    │    mWindowAttributes.type = 1
    │    ↓ ViewRootImpl.mView
    ├─ com.android.internal.policy.DecorView instance
    │    Leaking: NO (View attached)
    │    View is part of a window view hierarchy
    │    View.mAttachInfo is not null (view attached)
    │    View.mWindowAttachCount = 1
    │    mContext instance of com.android.internal.policy.DecorContext, wrapping activity app.becoach.android.coach.
    │    CoachTabBarActivity with mDestroyed = false
    │    ↓ View.mListenerInfo
    │           ~~~~~~~~~~~~~
    ├─ android.view.View$ListenerInfo instance
    │    Leaking: UNKNOWN
    │    Retaining 579.3 kB in 7126 objects
    │    ↓ View$ListenerInfo.mOnApplyWindowInsetsListener
    │                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ├─ com.vanniktech.emoji.EmojiPopup$5 instance
    │    Leaking: UNKNOWN
    │    Retaining 579.1 kB in 7120 objects
    │    Anonymous class implementing android.view.View$OnApplyWindowInsetsListener
    │    ↓ EmojiPopup$5.this$0
    │                   ~~~~~~
```