### PR TITLE
Fix: correct Emoji Popup height on devices with gesture navigation

### DIFF
--- a/emoji/src/androidMain/kotlin/com/vanniktech/emoji/EmojiPopup.kt
+++ b/emoji/src/androidMain/kotlin/com/vanniktech/emoji/EmojiPopup.kt
@@ -279,10 +279,11 @@ class EmojiPopup @JvmOverloads constructor(
           0
         }
 
-        val offset = if (systemWindowInsetBottom < (stableInsetBottom + gesturesInsetBottom)) {
+        val insetBottom = stableInsetBottom + gesturesInsetBottom
+        val offset = if (systemWindowInsetBottom < insetBottom) {
           systemWindowInsetBottom
         } else {
-          systemWindowInsetBottom - stableInsetBottom - gesturesInsetBottom
+          systemWindowInsetBottom - insetBottom
         }
 
         if (offset != previousOffset || offset == 0) {


### PR DESCRIPTION
Thank you for this amazing library! We've been using it for a really long time now and love it. We don't want to use anything else, but this little issue was troubling us.

### Problem
As described in issue #758, the emoji popup's height is calculated incorrectly on devices that use gesture navigation. This causes the popup to partially obscure other elements in the layout or the navigation bar, as the space occupied by the system's navigation bar is not accounted for.

### Solution
This PR fixes the height calculation within `EmojiPopup.onApplyWindowInsets` by properly accounting for the bottom system gesture insets. I've introduced the use of gesturesInsetBottom to correctly calculate the total offset. This ensures that the final `popupWindow.height` respects the area reserved for the gesture navigation bar on modern Android devices.

Changes were tested in Samsung Galaxy A40, Samsung Galaxy S23, Google Pixel 6a and Google Pixel 8 and worked!

Let me know if any changes are needed! Thanks again!