### PR TITLE
Fix documentation typo

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -17,7 +17,7 @@ The script does three things:
 
 ## Running the script
 
-Go the the `generator` directory:
+Go to the `generator` directory:
 
 ```bash
 cd generator


### PR DESCRIPTION
Small documentation typo noticed in UPDATING.md:

- `UPDATING.md`: "Go the the `generator` directory:" -> "Go to the `generator` directory:" (matches the `cd generator` step that follows)

Documentation only; no code changes.
